### PR TITLE
fixed clock delay bug for gridnode and updated gcc ignore pragmas

### DIFF
--- a/sst-bench/grid/gridnode.cc
+++ b/sst-bench/grid/gridnode.cc
@@ -275,7 +275,7 @@ bool GridNode::clockTick( SST::Cycle_t currentCycle ){
   if( curCycle >= clkDelay ){
     sendData();
     curCycle = 0;
-    clkDelay = localRNG->generateNextUInt32() % (maxDelay-minDelay+1) + minData;
+    clkDelay = localRNG->generateNextUInt32() % (maxDelay-minDelay+1) + minDelay;
   }
 
   // check to see if we've reached the completion state

--- a/sst-bench/grid/gridnode.h
+++ b/sst-bench/grid/gridnode.h
@@ -19,7 +19,6 @@
 #include <random>
 #include <stdio.h>
 #include <stdlib.h>
-// #include <inttypes.h>
 #include <time.h>
 
 // -- SST Headers

--- a/sst-bench/include/SST.h
+++ b/sst-bench/include/SST.h
@@ -29,6 +29,7 @@
 #else
 #pragma GCC diagnostic ignored "-Wimplicit-int-conversion"
 #pragma GCC diagnostic ignored "-Wshorten-64-to-32"
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
 
 // The #include order is important, so we prevent clang-format from reordering


### PR DESCRIPTION
Fixes bug found by inspection by Shannon where random clock delay was being incorrectly calculated.
Also added another compile pragma to ignore Werror warnings introduced in sst-core.

Will make a similar change in set-tools version of this code.