### PR TITLE
Semicolon required for SST_SER macros 

### DIFF
--- a/sst-bench/chkpnt/chkpnt.cc
+++ b/sst-bench/chkpnt/chkpnt.cc
@@ -75,15 +75,15 @@ void Chkpnt::printStatus( Output& out ){
 
 void Chkpnt::serialize_order(SST::Core::Serialization::serializer& ser){
   SST::Component::serialize_order(ser);
-  SST_SER(clockHandler)
-  SST_SER(numPorts)
-  SST_SER(minData)
-  SST_SER(maxData)
-  SST_SER(clockDelay)
-  SST_SER(clocks)
-  SST_SER(curCycle)
-  SST_SER(mersenne)
-  SST_SER(linkHandlers)
+  SST_SER(clockHandler);
+  SST_SER(numPorts);
+  SST_SER(minData);
+  SST_SER(maxData);
+  SST_SER(clockDelay);
+  SST_SER(clocks);
+  SST_SER(curCycle);
+  SST_SER(mersenne);
+  SST_SER(linkHandlers);
 }
 
 void Chkpnt::handleEvent(SST::Event *ev){

--- a/sst-bench/chkpnt/chkpnt.h
+++ b/sst-bench/chkpnt/chkpnt.h
@@ -53,7 +53,7 @@ private:
   /// ChkpntEvent: serialization method
   void serialize_order(SST::Core::Serialization::serializer& ser) override{
     Event::serialize_order(ser);
-    SST_SER(data)
+    SST_SER(data);
   }
 
   /// ChkpntEvent: serialization implementor

--- a/sst-bench/grid/gridnode.cc
+++ b/sst-bench/grid/gridnode.cc
@@ -134,27 +134,27 @@ void GridNode::printStatus( Output& out ){
 
 void GridNode::serialize_order(SST::Core::Serialization::serializer& ser){
   SST::Component::serialize_order(ser);
-  SST_SER(cptBegin)
-  SST_SER(clockHandler)
-  SST_SER(numBytes)
-  SST_SER(numPorts)
-  SST_SER(minData)
-  SST_SER(maxData)
-  SST_SER(minDelay)
-  SST_SER(maxDelay)
-  SST_SER(clkDelay)
-  SST_SER(clocks)
-  SST_SER(rngSeed)
-  SST_SER(state)
-  SST_SER(curCycle)
-  SST_SER(portname)
-  SST_SER(rng)
-  SST_SER(localRNG)
-  SST_SER(linkHandlers)
-  SST_SER(demoBug)
-  SST_SER(dataMask)
-  SST_SER(dataMax)
-  SST_SER(cptEnd)
+  SST_SER(cptBegin);
+  SST_SER(clockHandler);
+  SST_SER(numBytes);
+  SST_SER(numPorts);
+  SST_SER(minData);
+  SST_SER(maxData);
+  SST_SER(minDelay);
+  SST_SER(maxDelay);
+  SST_SER(clkDelay);
+  SST_SER(clocks);
+  SST_SER(rngSeed);
+  SST_SER(state);
+  SST_SER(curCycle);
+  SST_SER(portname);
+  SST_SER(rng);
+  SST_SER(localRNG);
+  SST_SER(linkHandlers);
+  SST_SER(demoBug);
+  SST_SER(dataMask);
+  SST_SER(dataMax);
+  SST_SER(cptEnd);
 }
 
 void GridNode::handleEvent(SST::Event *ev){

--- a/sst-bench/grid/gridnode.h
+++ b/sst-bench/grid/gridnode.h
@@ -53,7 +53,7 @@ private:
   /// GridNodeEvent: serialization method
   void serialize_order(SST::Core::Serialization::serializer& ser) override{
     Event::serialize_order(ser);
-    SST_SER(data)
+    SST_SER(data);
   }
 
   /// GridNodeEvent: serialization implementor

--- a/sst-bench/large-stat-chkpnt/large-stat-chkpnt.cc
+++ b/sst-bench/large-stat-chkpnt/large-stat-chkpnt.cc
@@ -57,10 +57,10 @@ namespace SST::LargeStatChkpnt{
 
   void LargeStatChkpnt::serialize_order(SST::Core::Serialization::serializer& ser){
     SST::Component::serialize_order(ser);
-    SST_SER(clockHandler)
-    SST_SER(numStats)
-    SST_SER(numClocks)
-    SST_SER(VStat)
+    SST_SER(clockHandler);
+    SST_SER(numStats);
+    SST_SER(numClocks);
+    SST_SER(VStat);
   }
 
   bool LargeStatChkpnt::clockTick( SST::Cycle_t currentCycle ){

--- a/sst-bench/restart/restart.cc
+++ b/sst-bench/restart/restart.cc
@@ -64,11 +64,11 @@ void Restart::printStatus( Output& out ){
 
 void Restart::serialize_order(SST::Core::Serialization::serializer& ser){
   SST::Component::serialize_order(ser);
-  SST_SER(clockHandler)
-  SST_SER(numBytes)
-  SST_SER(clocks)
-  SST_SER(baseSeed)
-  SST_SER(data)
+  SST_SER(clockHandler);
+  SST_SER(numBytes);
+  SST_SER(clocks);
+  SST_SER(baseSeed);
+  SST_SER(data);
 }
 
 bool Restart::clockTick( SST::Cycle_t currentCycle ){

--- a/sst-bench/restore/restore.cc
+++ b/sst-bench/restore/restore.cc
@@ -66,11 +66,11 @@ void Restore::printStatus( Output& out ){
 
 void Restore::serialize_order(SST::Core::Serialization::serializer& ser){
   SST::Component::serialize_order(ser);
-  SST_SER(clockHandler)
-  SST_SER(numBytes)
-  SST_SER(clocks)
-  SST_SER(mersenne)
-  SST_SER(data)
+  SST_SER(clockHandler);
+  SST_SER(numBytes);
+  SST_SER(clocks);
+  SST_SER(mersenne);
+  SST_SER(data);
 }
 
 bool Restore::clockTick( SST::Cycle_t currentCycle ){


### PR DESCRIPTION
This just adds a semicolon to SST_SER macros so that we can compile clean with Lee's sst-core branch, `generalize_serialize`
