### PR TITLE
Checkpoint starting index support for SST 14 and --dev (SST 15)

### DIFF
--- a/test/grid/CMakeLists.txt
+++ b/test/grid/CMakeLists.txt
@@ -9,6 +9,13 @@
 
 file(GLOB GRID_TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} 2d.py)
 
+# Checkpoint numbering version dependent
+if(${SST_MAJOR_VERSION} GREATER 14)
+  set(CPT_N 101)
+else()
+  set(CPT_N 100)
+endif()
+
 if(SSTBENCH_ENABLE_TESTING)
   set (passRegex "Simulation is complete")
   foreach(testSrc ${GRID_TEST_SRCS})
@@ -24,7 +31,7 @@ if(SSTBENCH_ENABLE_TESTING)
       PASS_REGULAR_EXPRESSION "${passRegex}")
     add_test(NAME ${testName}_RESTORE
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/grid --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_100_1010000/${CHKPT_PFX}_100_1010000.sstcpt)
+      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/grid --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_${CPT_N}_1010000/${CHKPT_PFX}_${CPT_N}_1010000.sstcpt)
     set_tests_properties(${testName}_RESTORE
       PROPERTIES
       TIMEOUT 60

--- a/test/restart/CMakeLists.txt
+++ b/test/restart/CMakeLists.txt
@@ -9,6 +9,13 @@
 
 file(GLOB RESTART_TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
 
+# Checkpoint numbering version dependent
+if(${SST_MAJOR_VERSION} GREATER 14)
+  set(CPT_N 1)
+else()
+  set(CPT_N 0)
+endif()
+
 if(SSTBENCH_ENABLE_TESTING)
   set (passRegex "Simulation is complete")
 
@@ -25,7 +32,7 @@ if(SSTBENCH_ENABLE_TESTING)
       PASS_REGULAR_EXPRESSION "${passRegex}")
     add_test(NAME ${testName}_RESTORE
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/restore --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_0_5000000/${CHKPT_PFX}_0_5000000.sstcpt)
+      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/restore --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_${CPT_N}_5000000/${CHKPT_PFX}_${CPT_N}_5000000.sstcpt)
     set_tests_properties(${testName}_RESTORE
       PROPERTIES
       TIMEOUT 60

--- a/test/restore/CMakeLists.txt
+++ b/test/restore/CMakeLists.txt
@@ -9,6 +9,13 @@
 
 file(GLOB RESTORE_TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
 
+# Checkpoint numbering version dependent
+if(${SST_MAJOR_VERSION} GREATER 14)
+  set(CPT_N 1)
+else()
+  set(CPT_N 0)
+endif()
+
 if(SSTBENCH_ENABLE_TESTING)
   set (passRegex "Simulation is complete")
 
@@ -25,7 +32,7 @@ if(SSTBENCH_ENABLE_TESTING)
       PASS_REGULAR_EXPRESSION "${passRegex}")
     add_test(NAME ${testName}_RESTORE
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/restore --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_0_5000000/${CHKPT_PFX}_0_5000000.sstcpt)
+      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/restore --load-checkpoint ${CHKPT_PFX}/${CHKPT_PFX}_${CPT_N}_5000000/${CHKPT_PFX}_${CPT_N}_5000000.sstcpt)
     set_tests_properties(${testName}_RESTORE
       PROPERTIES
       TIMEOUT 60


### PR DESCRIPTION
The latest sst-core devel branch starts the checkpoint counter at 1 instead of 0 which means the fixed paths specified in our tests need to be updated.  If the sst major version is greater than 14 we'll use the 1 as the starting count.