### PR TITLE
Adding thread performance benchmark and associated scripts

### DIFF
--- a/benchmarks/noodle/noodle-bench.py
+++ b/benchmarks/noodle/noodle-bench.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# noodle-bench.py
+#
+#
+
+import os
+import argparse
+import random
+import sst
+
+parser = argparse.ArgumentParser(description="Noodle Bench")
+parser.add_argument("--verbose", type=int, help="Verbosity", default=0)
+parser.add_argument("--numComps", type=int, help="Number of Noodle components", default=2)
+parser.add_argument("--portsPerComp", type=int, help="Number of ports per component", default=2)
+parser.add_argument("--msgPerClock", type=int, help="Messages per clock cycle", default=2)
+parser.add_argument("--bytesPerClock", type=int, help="Bytes per clock", default=4)
+parser.add_argument("--clocks", type=int, help="Number of clock cycles to execute", default=1000000)
+parser.add_argument("--rngSeed", type=int, help="RNG Seed", default=3131)
+args = parser.parse_args()
+
+print("Noodle-Bench test SST Simulation Configuration:")
+for arg in vars(args):
+    print("\t", arg, " = ", getattr(args, arg))
+
+# build the endpoint list
+endpoints = []
+for comp in range(args.numComps):
+    c = sst.Component("n"+str(comp), "noodle.Noodle")
+    c.addParams({
+        "verbose" : args.verbose,
+        "clockFreq" : "1GHz",
+        "numPorts" : args.portsPerComp,
+        "msgPerClock" : args.msgPerClock,
+        "bytesPerClock" : args.bytesPerClock,
+        "clocks" : args.clocks,
+        "rngSeed" : args.rngSeed
+    })
+
+    for port in range(args.portsPerComp):
+        ltuple = (c, "n" + str(comp), port)
+        endpoints.append(ltuple)
+
+if len(endpoints) % 2 != 0:
+    print(f"Warning: Odd number of endpoints ({len(endpoints)}). Removing one.")
+    endpoints.pop()
+#print("Noodle-Bench endpoint list")
+#print(endpoints)
+
+# randomly select two endpoints to connect
+while len(endpoints) >= 2:
+    random.shuffle(endpoints)
+    end1 = endpoints.pop()
+    end2 = endpoints.pop()
+
+    #print(f"Connecting endpoints: {end1} : {end2}")
+
+    link = sst.Link("link_" + str(end1[1]) + "p" + str(end1[2]) + "_" +
+                    str(end2[1]) + "p" + str(end2[2]))
+    link.connect( (end1[0], "port"+str(end1[2]), "1us"),
+                    (end2[0], "port"+str(end2[2]), "1us") )
+
+# EOF

--- a/benchmarks/noodle/noodle-strong-scaling.sh
+++ b/benchmarks/noodle/noodle-strong-scaling.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# noodle-strong-scaling.sh
+# aka, increase the thread count, but problem size remains constant
+#
+
+MODEL_OPTIONS="--portsPerComp 100 --numComps 100 --msgPerClock 8"
+OUTFILE="strong-scaling.csv"
+SDL="noodle-bench.py"
+
+if [ $# -ne 2 ]; then
+  echo "Usage: noodle-strong-scaling.sh MINTHREADS MAXTHREADS"
+fi
+
+if [ $1 -ge $2 ]; then
+    echo "Error: MINTHREADS ($1) must be less than MAXTHREADS ($2)."
+    exit 1
+fi
+
+MINT=$1
+MAXT=$2
+
+echo "Noodle Strong Scaling Config:"
+echo "- MINTHREADS = $MINT"
+echo "- MAXTHREADS = $MAXT"
+echo "- MODEL_OPTIONS = $MODEL_OPTIONS"
+echo "- OUTFILE = $OUTFILE"
+
+if [ -f "$filename" ]; then
+  rm -Rf $OUTFILE
+else
+  touch $OUTFILE
+fi
+
+while [ $MINT -le $MAXT ]
+do
+  echo "executing $MINT threads"
+  TIMING=`sst -v -n $MINT --model-options="$MODEL_OPTIONS" $SDL | grep "Total time:" | awk '{print $3}'`
+  echo "$MINT,$TIMING" >> $OUTFILE 2>&1
+  MINT=$(($MINT + 1))
+done
+
+echo "noodle-strong-scaling complete"

--- a/benchmarks/noodle/noodle-weak-scaling.sh
+++ b/benchmarks/noodle/noodle-weak-scaling.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# noodle-weak-scaling.sh
+# aka, increase the thread count and the problem size
+#
+
+MODEL_OPTIONS="--portsPerComp 100 --msgPerClock 8"
+OUTFILE="weak-scaling.csv"
+SDL="noodle-bench.py"
+COMPBASE=100
+
+if [ $# -ne 3 ]; then
+  echo "Usage: noodle-weak-scaling.sh MINTHREADS MAXTHREADS COMPSTEP"
+fi
+
+if [ $1 -ge $2 ]; then
+    echo "Error: MINTHREADS ($1) must be less than MAXTHREADS ($2)."
+    exit 1
+fi
+
+MINT=$1
+MAXT=$2
+STEP=$3
+
+echo "Noodle Strong Scaling Config:"
+echo "- MINTHREADS = $MINT"
+echo "- MAXTHREADS = $MAXT"
+echo "- COMPBASE = $COMPBASE"
+echo "- COMPSTEP = $STEP"
+echo "- MODEL_OPTIONS = $MODEL_OPTIONS"
+echo "- OUTFILE = $OUTFILE"
+
+if [ -f "$filename" ]; then
+  rm -Rf $OUTFILE
+else
+  touch $OUTFILE
+fi
+
+while [ $MINT -le $MAXT ]
+do
+  echo "executing $MINT threads"
+  TIMING=`sst -v -n $MINT --model-options="$MODEL_OPTIONS --numComps $COMPBASE" $SDL | grep "Total time:" | awk '{print $3}'`
+  echo "$MINT,$COMPBASE,$TIMING" >> $OUTFILE 2>&1
+  MINT=$(($MINT + 1))
+  COMPBASE=$(($COMPBASE + $STEP))
+done
+
+echo "noodle-strong-scaling complete"

--- a/sst-bench/CMakeLists.txt
+++ b/sst-bench/CMakeLists.txt
@@ -43,6 +43,11 @@ elseif(${SST_MAJOR_VERSION} GREATER 14)
   add_subdirectory(large-stat-chkpnt)
 endif()
 
+if(${SST_MAJOR_VERSION} GREATER_EQUAL 15)
+  message(STATUS "[SST-BENCH] Enabling NOODLE micro-benchmark")
+  add_subdirectory(noodle)
+endif()
+
 if(${ENABLE_SSTDBG})
   message(STATUS "[SST-BENCH] Enabling TCL-DBG micro-benchmark")
   add_subdirectory(tcl-dbg)

--- a/sst-bench/noodle/CMakeLists.txt
+++ b/sst-bench/noodle/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# sst-bench/sst-bench/noodle CMake
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+
+set(NoodleSrcs
+  noodle.cc
+  noodle.h
+)
+
+add_library(noodle SHARED ${NoodleSrcs})
+target_include_directories(noodle PUBLIC ${SST_INSTALL_DIR}/include)
+install(TARGETS noodle DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+install(CODE "execute_process(COMMAND sst-register noodle noodle_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
+
+# EOF

--- a/sst-bench/noodle/noodle.cc
+++ b/sst-bench/noodle/noodle.cc
@@ -1,0 +1,134 @@
+//
+// _noodle_cc_
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "noodle.h"
+
+namespace SST::Noodle{
+
+//------------------------------------------
+// Noodle
+//------------------------------------------
+Noodle::Noodle(SST::ComponentId_t id, const SST::Params& params ) :
+  SST::Component( id ), timeConverter(nullptr), clockHandler(nullptr),
+  numPorts(2), msgsPerClock(8), bytesPerClock(8), portsPerClock(1),
+  clocks(10000), rngSeed(31337) {
+
+  uint32_t Verbosity = params.find< uint32_t >( "verbose", 0 );
+  output.init(
+    "Noodle[" + getName() + ":@p:@t]: ",
+    Verbosity, 0, SST::Output::STDOUT );
+  const std::string cpuClock = params.find< std::string >("clockFreq", "1GHz");
+  clockHandler  = new SST::Clock::Handler2<Noodle,&Noodle::clockTick>(this);
+  timeConverter = registerClock(cpuClock, clockHandler);
+  registerAsPrimaryComponent();
+  primaryComponentDoNotEndSim();
+
+  // read the rest of the parameters
+  numPorts = params.find<uint64_t>("numPorts", 2);
+  msgsPerClock = params.find<uint64_t>("msgsPerClock", 8);
+  bytesPerClock = params.find<uint64_t>("bytesPerClock", 8);
+  portsPerClock = params.find<uint64_t>("portsPerClock", 1);
+  clocks = params.find<uint64_t>("clocks", 10000);
+  rngSeed = params.find<uint32_t>("rngSeed", 31337);
+
+  // sanity check the port configs
+  if( portsPerClock > numPorts ){
+    output.fatal( CALL_INFO, -1, "%s : numPorts < portsPerClock\n",
+                 getName().c_str());
+  }
+
+  // setup the port handlers
+  portname.resize(numPorts);
+  for( uint64_t i=0; i<numPorts; i++ ){
+    portname[i] = "port" + std::to_string(i);
+    linkHandlers.push_back(configureLink("port"+std::to_string(i),
+                                         new Event::Handler2<Noodle,
+                                         &Noodle::handleEvent>(this)));
+  }
+
+  // setup the local random number generator
+  localRNG = new SST::RNG::MersenneRNG(uint32_t(id) + rngSeed);
+
+  // constructor complete
+  output.verbose( CALL_INFO, 5, 0, "Constructor complete\n" );
+}
+
+Noodle::~Noodle(){
+  if (localRNG) delete localRNG;
+}
+
+void Noodle::setup(){
+}
+
+void Noodle::finish(){
+}
+
+void Noodle::init( unsigned int phase ){
+}
+
+void Noodle::handleEvent(SST::Event *ev){
+  NoodleEvent *ne = static_cast<NoodleEvent*>(ev);
+  auto data = ne->getData();
+  output.verbose(CALL_INFO, 5, 0,
+                 "%s: received %zu bytes\n",
+                 getName().c_str(),
+                 data.size());
+  delete ev;
+}
+
+void Noodle::sendData(){
+  std::vector<uint64_t> sendPorts;
+
+  // build a list of ports to send data over, note that there can be duplicates
+  if( numPorts > 1 ){
+    for( uint64_t i=0; i<portsPerClock; i++ ){
+      sendPorts.push_back(localRNG->generateNextUInt64() % (numPorts-1));
+    }
+  }else{
+    // single port configured
+    sendPorts.push_back(0);
+  }
+
+  // build a sample packet
+  std::vector<uint8_t> packet;
+  for( uint64_t s = 0x00ull; s < bytesPerClock; s++ ){
+    packet.push_back( (uint8_t)(localRNG->generateNextUInt32() & 0b11111111) );
+  }
+
+  // build packets for each port
+  for( const auto &p : sendPorts ){
+    // build some number of packets for port `p`
+    output.verbose( CALL_INFO, 9, 0, "sendData for port = %s\n",
+                    portname[p].c_str() );
+    for( uint64_t m = 0x00ull; m < msgsPerClock; m++ ){
+      // send message 'm' through port 'p'
+      NoodleEvent *ne = new NoodleEvent(packet);
+      linkHandlers[p]->send(ne);
+    }
+  }
+}
+
+bool Noodle::clockTick(SST::Cycle_t currentCycle){
+  if( (uint64_t)(currentCycle) >= clocks ){
+    output.verbose(CALL_INFO, 1, 0,
+                   "%s is ready to end simulation\n",
+                   getName().c_str());
+    primaryComponentOKToEndSim();
+    return true;
+  }
+
+  sendData();
+
+  return false;
+}
+
+} // namespace SST::Noodle
+
+// EOF

--- a/sst-bench/noodle/noodle.h
+++ b/sst-bench/noodle/noodle.h
@@ -1,0 +1,186 @@
+//
+// _noodle_h_
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_NOODLE_H_
+#define _SST_NOODLE_H_
+
+// -- Standard Headers
+#include <map>
+#include <vector>
+#include <queue>
+#include <random>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+// clang-format off
+// -- SST Headers
+#include "SST.h"
+#include <sst/core/rng/distrib.h>
+#include <sst/core/rng/rng.h>
+#include <sst/core/rng/mersenne.h>
+// clang-format on
+
+namespace SST::Noodle{
+
+// -------------------------------------------------------
+// NoodleEvent
+// -------------------------------------------------------
+class NoodleEvent : public SST::Event{
+public:
+  /// NoodleEvent: standard constructor
+  NoodleEvent() : SST::Event() {}
+
+  /// NoodleEvent: constructor
+  NoodleEvent(std::vector<uint8_t> d) : SST::Event(), data(d) {}
+
+  /// NoodleEvent: destructor
+  ~NoodleEvent() {}
+
+  /// NoodleEvent: retrieve the data
+  std::vector<uint8_t> const getData() { return data; }
+
+private:
+  std::vector<uint8_t>  data;   ///< NoodleEvent: data payload
+
+  /// NoodleEvent: serialization method
+  void serialize_order(SST::Core::Serialization::serializer& ser) override{
+    Event::serialize_order(ser);
+    SST_SER(data);
+  }
+
+  /// NoodleEvent: serialization implementor
+  ImplementSerializable(SST::Noodle::NoodleEvent);
+
+};  // class NoodleEvent
+
+
+// -------------------------------------------------------
+// Noodle
+// -------------------------------------------------------
+class Noodle final : public SST::Component{
+public:
+  /// Noodle: top-level SST component constructor
+  Noodle( SST::ComponentId_t id, const SST::Params& params );
+
+  /// Noodle: top-level SST destructor
+  ~Noodle();
+
+  /// Noodle: standard SST component 'setup' function
+  void setup() override;
+
+  /// Noodle: standard SST component 'finish' function
+  void finish() override;
+
+  /// Noodle: standard SST component 'init' function
+  void init( unsigned int phase ) override;
+
+  /// Noodle: standard SST component clock function
+  bool clockTick( SST::Cycle_t currentCycle );
+
+  // -------------------------------------------------------
+  // Noodle Component Registration Data
+  // -------------------------------------------------------
+  /// Noodle: Register the component with the SST core
+  SST_ELI_REGISTER_COMPONENT( Noodle,     // component class
+                              "noodle",       // component library
+                              "Noodle",   // component name
+                              SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
+                              "NOODLE SST COMPONENT",
+                              COMPONENT_CATEGORY_UNCATEGORIZED )
+
+  SST_ELI_DOCUMENT_PARAMS(
+    {"verbose",             "Sets the verbosity level",                   "0" },
+    {"clockFreq",           "Sets the clock frequency",                   "1GHz" },
+    {"numPorts",            "Sets the number of ports",                   "2" },
+    {"msgsPerClock",        "Sets the number of messages sent per clock", "8" },
+    {"bytesPerClock",       "Sets the number of bytes per clock",         "8" },
+    {"portsPerClock",       "Sets the number of ports to send per clock", "1" },
+    {"clocks",              "Sets the number of clocks to execute",       "10000"},
+    {"rngSeed",             "Sets the RNG seed",                          "31337"},
+  )
+
+  // -------------------------------------------------------
+  // Noodle Component Port Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_PORTS(
+    {"port%(num_ports)d",
+      "Ports which connect to endpoints.",
+      {"noodle.NoodleEvent", ""}
+    }
+  )
+
+  // -------------------------------------------------------
+  // Noodle SubComponent Parameter Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS()
+
+  // -------------------------------------------------------
+  // Noodle Component Statistics Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_STATISTICS()
+
+  // -------------------------------------------------------
+  // Noodle Component Checkpoint Methods
+  // -------------------------------------------------------
+  /// Noodle: serialization constructor
+  Noodle() : SST::Component() {}
+
+  /// Noodle: serialization
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    SST::Component::serialize_order(ser);
+    SST_SER(clockHandler);
+    SST_SER(numPorts);
+    SST_SER(msgsPerClock);
+    SST_SER(bytesPerClock);
+    SST_SER(portsPerClock);
+    SST_SER(clocks);
+    SST_SER(rngSeed);
+    SST_SER(portname);
+    SST_SER(linkHandlers);
+    SST_SER(localRNG);
+  }
+
+  /// Noodle: serialization implementations
+  ImplementSerializable(SST::Noodle::Noodle)
+
+private:
+  // -- internal handlers
+  SST::Output    output;                          ///< SST output handler
+  TimeConverter* timeConverter;                   ///< SST time conversion handler
+  SST::Clock::HandlerBase* clockHandler;          ///< Clock Handler
+
+  // -- parameters
+  uint64_t numPorts;                              ///< number of ports
+  uint64_t msgsPerClock;                          ///< number of messages per clock
+  uint64_t bytesPerClock;                         ///< number of bytes per clock
+  uint64_t portsPerClock;                         ///< number of ports per clock to send data across
+  uint64_t clocks;                                ///< number of clocks to execute
+  uint32_t rngSeed;                               ///< rng seed
+
+  // -- internal state
+  std::vector<std::string> portname;              ///< port 0 to numPorts names
+  std::vector<SST::Link *> linkHandlers;          ///< LinkHandler objects
+  SST::RNG::Random* localRNG = 0;                 ///< component local random number generator
+
+  // -- private methods
+  /// Noodle: Message Event Handler
+  void handleEvent(SST::Event *ev);
+
+  /// Noodle: Sends data to an adjacent link
+  void sendData();
+
+};  // class Noodle
+
+} // namespace SST::Noodle
+
+#endif // _SST_NOODLE_H_
+
+// EOF

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,11 @@ if(${SST_14_1_MIN})
   add_subdirectory(grid)
 endif()
 
+if(${SST_MAJOR_VERSION} GREATER_EQUAL 15)
+  message(STATUS "[SST-BENCH] Enabling NOODLE testing")
+  add_subdirectory(noodle)
+endif()
+
 if(${ENABLE_SSTDBG})
   message(STATUS "[SST-BENCH] Enabling TCL-DBG testing")
   add_subdirectory(tcl-dbg)

--- a/test/noodle/CMakeLists.txt
+++ b/test/noodle/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# sst-bench/test/noodle CMake
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+
+file(GLOB NOODLE_TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
+
+if(SSTBENCH_ENABLE_TESTING)
+  set (passRegex "Simulation is complete")
+
+  foreach(testSrc ${NOODLE_TEST_SRCS})
+    get_filename_component(testName ${testSrc} NAME_WE)
+    add_test(NAME ${testName}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/noodle ${testSrc})
+    set_tests_properties(${testName}
+      PROPERTIES
+      TIMEOUT 30
+      LABELS "all"
+      PASS_REGULAR_EXPRESSION "${passRegex}")
+  endforeach(testSrc)
+endif()
+
+# EOF

--- a/test/noodle/noodle-test1.py
+++ b/test/noodle/noodle-test1.py
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# noodle-test1.py
+#
+
+import os
+import sst
+
+
+n0 = sst.Component("n0", "noodle.Noodle")
+n0.addParams({
+  "verbose"      : 9,
+  "clockFreq"    : "1GHz",
+  "numPorts"     : 1,
+  "msgPerClock"  : 1,
+  "bytesPerClock": 1,
+  "portsPerClock": 1,
+  "clocks"       : 100000,
+  "rngSeed"      : 3131
+})
+
+n1 = sst.Component("n1", "noodle.Noodle")
+n1.addParams({
+  "verbose"      : 9,
+  "clockFreq"    : "1GHz",
+  "numPorts"     : 1,
+  "msgPerClock"  : 1,
+  "bytesPerClock": 1,
+  "portsPerClock": 1,
+  "clocks"       : 100000,
+  "rngSeed"      : 3131
+})
+
+link0 = sst.Link("link0")
+link0.connect( (n0, "port0", "1us"), (n1, "port0", "1us") )
+
+# EOF

--- a/test/noodle/noodle-test2.py
+++ b/test/noodle/noodle-test2.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# noodle-test1.py
+#
+
+import os
+import sst
+
+
+n0 = sst.Component("n0", "noodle.Noodle")
+n0.addParams({
+  "verbose"      : 9,
+  "clockFreq"    : "1GHz",
+  "numPorts"     : 8,
+  "msgPerClock"  : 3,
+  "bytesPerClock": 4,
+  "portsPerClock": 3,
+  "clocks"       : 100000,
+  "rngSeed"      : 3131
+})
+
+n1 = sst.Component("n1", "noodle.Noodle")
+n1.addParams({
+  "verbose"      : 9,
+  "clockFreq"    : "1GHz",
+  "numPorts"     : 8,
+  "msgPerClock"  : 9,
+  "bytesPerClock": 7,
+  "portsPerClock": 5,
+  "clocks"       : 100000,
+  "rngSeed"      : 3131
+})
+
+link0 = sst.Link("link0")
+link1 = sst.Link("link1")
+link2 = sst.Link("link2")
+link3 = sst.Link("link3")
+link4 = sst.Link("link4")
+link5 = sst.Link("link5")
+link6 = sst.Link("link6")
+link7 = sst.Link("link7")
+link0.connect( (n0, "port0", "1us"), (n1, "port0", "1us") )
+link1.connect( (n0, "port1", "1us"), (n1, "port1", "1us") )
+link2.connect( (n0, "port2", "1us"), (n1, "port2", "1us") )
+link3.connect( (n0, "port3", "1us"), (n1, "port3", "1us") )
+link4.connect( (n0, "port4", "1us"), (n1, "port4", "1us") )
+link5.connect( (n0, "port5", "1us"), (n1, "port5", "1us") )
+link6.connect( (n0, "port6", "1us"), (n1, "port6", "1us") )
+link7.connect( (n0, "port7", "1us"), (n1, "port7", "1us") )
+
+# EOF


### PR DESCRIPTION
This includes a new benchmark component called `noodle`.  Noodle is a simple component that creates a variable number of ports connected to adjacent noodle components (no routers).  Users can configure the number of ports, size of the messages sent, number of messages per clock and the number of clocks to execute the benchmark.  This PR includes a sample benchmark script that randomly assigns ports between known components in a manner that looks like a spaghetti network (aka, **noodle**).  The goal being to elicit strange behavior in barrier synchronization performance when using strong and weakly scaled number of threads.  We also provide strong and weak scaling scripts that can executed on a target platform.  

Noodle options:
```
Parameters (8 total)
         verbose: Sets the verbosity level  [0]
         clockFreq: Sets the clock frequency  [1GHz]
         numPorts: Sets the number of ports  [2]
         msgsPerClock: Sets the number of messages sent per clock  [8]
         bytesPerClock: Sets the number of bytes per clock  [8]
         portsPerClock: Sets the number of ports to send per clock  [1]
         clocks: Sets the number of clocks to execute  [10000]
         rngSeed: Sets the RNG seed  [31337]
```  