### PR TITLE
adding spaghetti event driven component test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 endif()
 
 set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wconversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined ${WERROR_FLAG} ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall")
 
 #---------------------------------------------
 # TARGET OPTIONS

--- a/benchmarks/spaghetti/spaghetti-bench.py
+++ b/benchmarks/spaghetti/spaghetti-bench.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# spaghetti-bench.py
+#
+#
+
+import sys
+import os
+import argparse
+import random
+import sst
+
+parser = argparse.ArgumentParser(description="Spaghetti Bench")
+parser.add_argument("--verbose", type=int, help="Verbosity", default=0)
+parser.add_argument("--numComps", type=int, help="Number of Spaghetti components", default=2)
+parser.add_argument("--portsPerComp", type=int, help="Number of ports per component", default=2)
+parser.add_argument("--msgsPerPort", type=int, help="Number of msgs to inject per port", default=100)
+parser.add_argument("--bytesPerMsg", type=int, help="Number of bytes per message", default=64)
+parser.add_argument("--rngSeed", type=int, help="RNG seed value", default=3131)
+args = parser.parse_args()
+
+print("Spaghetti-Bench test SST Simulation Configuration:")
+for arg in vars(args):
+    print("\t", arg, " = ", getattr(args, arg))
+
+if args.numComps % 2 != 0:
+    print(f"Spaghetti-Bench requires an even number of components!")
+    sys.exit(-1)
+
+if args.portsPerComp % 2 != 0:
+    print(f"Spaghetti-Bench requires an even number of ports per component!")
+    sys.exit(-1)
+
+# create all the components
+endpoints = []
+for comp in range(args.numComps):
+    c = sst.Component("s"+str(comp), "spaghetti.Spaghetti")
+    c.addParams({
+        "verbose": args.verbose,
+        "numPorts" : args.portsPerComp,
+        "numMsgs" : args.msgsPerPort,
+        "bytesPerMsg" : args.bytesPerMsg,
+        "rngSeed" : args.rngSeed
+    })
+    endpoints.append(c)
+
+# setup a ring network of links
+# 50% of the links for each component go to the Nth+1 component
+# 50% of the links for each component go to the Nth-1 component
+for compLink in range(1, args.numComps):
+    # lower 50%
+    upperLink = args.portsPerComp-1
+    for lowerLink in range(0, int(args.portsPerComp/2)):
+        link = sst.Link("link_s" + str(compLink) + "p" + str(lowerLink) + "p" + str(upperLink))
+        link.connect( (endpoints[compLink],  "port"+str(lowerLink), "1us"),
+                      (endpoints[compLink-1],"port"+str(upperLink), "1us") )
+        upperLink = upperLink - 1
+
+# handle lowers links for component 0
+upperLink = args.portsPerComp-1
+for lowerLink in range(0, int(args.portsPerComp/2)):
+    link = sst.Link("link_s0p" + str(lowerLink) + "p" + str(upperLink))
+    link.connect( (endpoints[0], "port"+str(lowerLink), "1us"),
+                  (endpoints[args.numComps-1], "port"+str(upperLink), "1us") )
+    upperLink = upperLink - 1
+
+

--- a/sst-bench/CMakeLists.txt
+++ b/sst-bench/CMakeLists.txt
@@ -45,7 +45,9 @@ endif()
 
 if(${SST_MAJOR_VERSION} GREATER_EQUAL 15)
   message(STATUS "[SST-BENCH] Enabling NOODLE micro-benchmark")
+  message(STATUS "[SST-BENCH] Enabling SPAGHETTI micro-benchmark")
   add_subdirectory(noodle)
+  add_subdirectory(spaghetti)
 endif()
 
 if(${ENABLE_SSTDBG})

--- a/sst-bench/noodle/noodle.h
+++ b/sst-bench/noodle/noodle.h
@@ -150,7 +150,7 @@ public:
   }
 
   /// Noodle: serialization implementations
-  ImplementSerializable(SST::Noodle::Noodle)
+  ImplementSerializable(SST::Noodle::Noodle);
 
 private:
   // -- internal handlers

--- a/sst-bench/spaghetti/CMakeLists.txt
+++ b/sst-bench/spaghetti/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# sst-bench/sst-bench/spaghetti CMake
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+
+set(SpaghettiSrcs
+  spaghetti.cc
+  spaghetti.h
+)
+
+add_library(spaghetti SHARED ${SpaghettiSrcs})
+target_include_directories(spaghetti PUBLIC ${SST_INSTALL_DIR}/include)
+install(TARGETS spaghetti DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+install(CODE "execute_process(COMMAND sst-register spaghetti spaghetti_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
+
+# EOF

--- a/sst-bench/spaghetti/spaghetti.cc
+++ b/sst-bench/spaghetti/spaghetti.cc
@@ -1,0 +1,123 @@
+//
+// _spaghetti_cc_
+//
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "spaghetti.h"
+
+namespace SST::Spaghetti{
+
+//------------------------------------------
+// Noodle
+//------------------------------------------
+Spaghetti::Spaghetti(SST::ComponentId_t id, const SST::Params& params ) :
+  SST::Component( id ), numPorts(2), numMsgs(10), bytesPerMsg(64),
+  rngSeed(31337), numRecv(0), injectedData(false) {
+
+  uint32_t Verbosity = params.find<uint32_t>("verbose", 0);
+  output.init(
+    "Spaghetti[" + getName() + ":@p:@t]: ",
+    Verbosity, 0, SST::Output::STDOUT );
+
+  // register our component
+  registerAsPrimaryComponent();
+  primaryComponentDoNotEndSim();
+
+  // read the rest of the parameters
+  numPorts = params.find<uint64_t>("numPorts", 2);
+  numMsgs = params.find<uint64_t>("numMsgs", 10);
+  bytesPerMsg = params.find<uint64_t>("bytesPerMsg", 64);
+  rngSeed = params.find<uint32_t>("rngSeed", 31337);
+
+  // setup the port handlers
+  portname.resize(numPorts);
+  linkHandlers.resize(numPorts);
+  for( uint64_t i = 0; i<numPorts; i++ ){
+    portname[i] = "port" + std::to_string(i);
+    linkHandlers[i] = configureLink(portname[i],
+                                    new Event::Handler2<Spaghetti,
+                                    &Spaghetti::handleEvent>(this));
+  }
+
+  // setup the local rand number generator
+  localRNG = new SST::RNG::MersenneRNG(uint32_t(id) + rngSeed);
+
+  // constructor complete
+  output.verbose( CALL_INFO, 5, 0, "Constructor complete\n" );
+}
+
+Spaghetti::~Spaghetti(){
+  if( localRNG ) delete localRNG;
+}
+
+void Spaghetti::setup(){
+  if( !injectedData ){
+    sendData();
+    injectedData = true;
+  }
+  output.verbose( CALL_INFO, 5, 0, "Setup complete\n" );
+}
+
+void Spaghetti::finish(){
+  output.verbose( CALL_INFO, 5, 0, "Finish complete\n" );
+}
+
+void Spaghetti::init( unsigned int phase ){
+  output.verbose( CALL_INFO, 5, 0, "Init Phase=%d\n", 2 );
+}
+
+void Spaghetti::handleEvent(SST::Event *ev){
+  SpaghettiEvent *se = static_cast<SpaghettiEvent*>(ev);
+  auto data = se->getData();
+  output.verbose(CALL_INFO, 5, 0,
+                 "%s: received %zu bytes\n",
+                 getName().c_str(),
+                 data.size());
+  delete ev;
+
+  // check for completion status
+  numRecv+=1;
+  if( numRecv == (numMsgs*numPorts) ){
+    primaryComponentOKToEndSim();
+  }
+}
+
+void Spaghetti::sendData(){
+  output.verbose(CALL_INFO, 5, 0, "sendData()\n");
+  for( unsigned i=0; i<numPorts; i++ ){
+    for( unsigned j=0; j<numMsgs; j++ ){
+      // build a packet
+      std::vector<uint8_t> packet;
+      packet.resize(bytesPerMsg);
+      for( uint64_t m = 0x00ull; m<bytesPerMsg; m++ ){
+        packet[m] = ((uint8_t)(localRNG->generateNextUInt32() & 0b11111111));
+      }
+
+      // create the packet
+      SpaghettiEvent *se = new SpaghettiEvent(packet);
+
+      // create random time bases and delays using our localRNG
+      // time bases are restricted to three bits of precision, aka 7MHz
+      // delays are restrict to 8 bits of precision
+      TimeConverter tc = getTimeConverter(
+        std::to_string(localRNG->generateNextUInt32() & 0b111) + "MHz");
+      SimTime_t delay = (SimTime_t)(localRNG->generateNextUInt32() & 0b11111111);
+      linkHandlers[i]->send(delay, tc, se);
+
+      output.verbose(CALL_INFO, 5, 0,
+                     "%s: injected %zu byte message into port = %s\n",
+                     getName().c_str(),
+                     packet.size(),
+                     portname[i].c_str());
+    }
+  }
+}
+
+} // namespace SST::Spaghetti
+
+// EOF

--- a/sst-bench/spaghetti/spaghetti.h
+++ b/sst-bench/spaghetti/spaghetti.h
@@ -1,0 +1,176 @@
+//
+// _spaghetti_h_
+//
+// Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_SPAGHETTI_H_
+#define _SST_SPAGHETTI_H_
+
+// -- Standard Headers
+#include <map>
+#include <vector>
+#include <queue>
+#include <random>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+// clang-format off
+// -- SST Headers
+#include "SST.h"
+#include <sst/core/rng/distrib.h>
+#include <sst/core/rng/rng.h>
+#include <sst/core/rng/mersenne.h>
+// clang-format on
+
+namespace SST::Spaghetti{
+
+// -------------------------------------------------------
+// SpaghettiEvent
+// -------------------------------------------------------
+class SpaghettiEvent : public SST::Event{
+public:
+  /// SpaghettiEvent: standard constructor
+  SpaghettiEvent() : SST::Event() {}
+
+  /// SpaghettiEvent: constructor
+  SpaghettiEvent(std::vector<uint8_t> d) : SST::Event(), data(d) {}
+
+  /// SpaghettiEvent: destructor
+  ~SpaghettiEvent() {}
+
+  /// SpaghettiEvent: retrieve the data
+  std::vector<uint8_t> const getData() { return data; }
+
+private:
+  std::vector<uint8_t>  data;   ///< SpaghettiEvent: data payload
+
+  /// SpaghettiEvent: serialization method
+  void serialize_order(SST::Core::Serialization::serializer& ser) override{
+    Event::serialize_order(ser);
+    SST_SER(data);
+  }
+
+  /// SpaghettiEvent: serialization implementor
+  ImplementSerializable(SST::Spaghetti::SpaghettiEvent);
+
+};  // class SpaghettiEvent
+
+// -------------------------------------------------------
+// Spaghetti
+// -------------------------------------------------------
+class Spaghetti final : public SST::Component{
+public:
+  /// Spaghetti: top-level SST component constructor
+  Spaghetti( SST::ComponentId_t id, const SST::Params& params );
+
+  /// Spaghetti: top-level SST destructor
+  ~Spaghetti();
+
+  /// Spaghetti: standard SST component 'setup' function
+  void setup() override;
+
+  /// Spaghetti: standard SST component 'finish function
+  void finish() override;
+
+  /// Spaghetti: standard SST component 'init' function
+  void init( unsigned int phase ) override;
+
+
+  // -------------------------------------------------------
+  // Spaghetti Component Registration Data
+  // -------------------------------------------------------
+  /// Spaghetti: Register the component with the SST core
+  SST_ELI_REGISTER_COMPONENT( Spaghetti,      // component class
+                              "spaghetti",    // component library
+                              "Spaghetti",    // component name
+                              SST_ELI_ELEMENT_VERSION( 1, 0, 0 ),
+                              "SPAGHETTI SST COMPONENT",
+                              COMPONENT_CATEGORY_UNCATEGORIZED )
+
+  SST_ELI_DOCUMENT_PARAMS(
+    {"verbose",             "Sets the verbosity level",                       "0" },
+    {"numPorts",            "Sets the number of ports",                       "2" },
+    {"numMsgs",             "Sets the number of messages per port to inject", "10"},
+    {"bytesPerMsg",         "Sets the number of bytes per msg",               "64"},
+    {"rngSeed",             "Sets the RNG seed",                              "31337"},
+  )
+
+  // -------------------------------------------------------
+  // Spaghetti Component Port Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_PORTS(
+    {"port%(num_ports)d",
+      "Ports which connect to endpoints.",
+      {"spaghetti.SpaghettiEvent", ""}
+    }
+  )
+
+  // -------------------------------------------------------
+  // Spaghetti SubComponent Parameter Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS()
+
+  // -------------------------------------------------------
+  // Spaghetti Component Statistics Data
+  // -------------------------------------------------------
+  SST_ELI_DOCUMENT_STATISTICS()
+
+  // -------------------------------------------------------
+  // Spaghetti Component Checkpoint Methods
+  // -------------------------------------------------------
+  /// Spaghetti: serialization constructor
+  Spaghetti() : SST::Component() {}
+
+  /// Spaghetti serialization
+  void serialize_order(SST::Core::Serialization::serializer& ser) override {
+    SST::Component::serialize_order(ser);
+    SST_SER(numPorts);
+    SST_SER(numMsgs);
+    SST_SER(bytesPerMsg);
+    SST_SER(rngSeed);
+    SST_SER(numRecv);
+    SST_SER(portname);
+    SST_SER(linkHandlers);
+    SST_SER(localRNG);
+  }
+
+  /// Spaghetti: serialization implementations
+  ImplementSerializable(SST::Spaghetti::Spaghetti);
+
+private:
+  // -- internal handlers
+  SST::Output    output;                          ///< SST output handler
+
+  // -- parameters
+  uint64_t numPorts;                              ///< number of ports
+  uint64_t numMsgs;                               ///< number of messages per clock
+  uint64_t bytesPerMsg;                           ///< number of bytes per clock
+  uint32_t rngSeed;                               ///< rng seed
+
+  // -- internal state
+  uint64_t numRecv;                               ///< number of messages received
+  bool injectedData;                              ///< determines whether the messages have been sent
+  std::vector<std::string> portname;              ///< port 0 to numPorts names
+  std::vector<SST::Link *> linkHandlers;          ///< LinkHandler objects
+  SST::RNG::Random* localRNG = 0;                 ///< component local random number generator
+
+  // -- private methods
+  /// Spaghetti: Message Event Handler
+  void handleEvent(SST::Event *ev);
+
+  /// Spaghetti: Sends data to an adjacent link
+  void sendData();
+
+};
+
+} // namespace SST::Spaghetti
+
+#endif  // _SST_SPAGHETTI_H_
+
+// EOF

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,9 @@ endif()
 
 if(${SST_MAJOR_VERSION} GREATER_EQUAL 15)
   message(STATUS "[SST-BENCH] Enabling NOODLE testing")
+  message(STATUS "[SST-BENCH] Enabling SPAGHETTI testing")
   add_subdirectory(noodle)
+  add_subdirectory(spaghetti)
 endif()
 
 if(${ENABLE_SSTDBG})

--- a/test/noodle/noodle-test2.py
+++ b/test/noodle/noodle-test2.py
@@ -5,7 +5,7 @@
 #
 # See LICENSE in the top level directory for licensing details
 #
-# noodle-test1.py
+# noodle-test2.py
 #
 
 import os

--- a/test/spaghetti/CMakeLists.txt
+++ b/test/spaghetti/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# sst-bench/test/spaghetti CMake
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+# See LICENSE in the top level directory for licensing details
+#
+
+file(GLOB SPAGHETTI_TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
+
+if(SSTBENCH_ENABLE_TESTING)
+  set (passRegex "Simulation is complete")
+
+  foreach(testSrc ${SPAGHETTI_TEST_SRCS})
+    get_filename_component(testName ${testSrc} NAME_WE)
+    add_test(NAME ${testName}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND sst --add-lib-path=${CMAKE_BINARY_DIR}/sst-bench/spaghetti ${testSrc})
+    set_tests_properties(${testName}
+      PROPERTIES
+      TIMEOUT 30
+      LABELS "all"
+      PASS_REGULAR_EXPRESSION "${passRegex}")
+  endforeach(testSrc)
+endif()
+
+# EOF

--- a/test/spaghetti/spaghetti-test1.py
+++ b/test/spaghetti/spaghetti-test1.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# spaghetti-test1.py
+#
+
+import os
+import sst
+
+
+s0 = sst.Component("s0", "spaghetti.Spaghetti")
+s0.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 2,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3131
+})
+
+s1 = sst.Component("s1", "spaghetti.Spaghetti")
+s1.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 2,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3731
+})
+
+link0 = sst.Link("link0")
+link0.connect( (s0, "port0", "1us"), (s1, "port0", "1us") )
+
+link1 = sst.Link("link1")
+link1.connect( (s0, "port1", "1us"), (s1, "port1", "1us") )
+
+# EOF

--- a/test/spaghetti/spaghetti-test2.py
+++ b/test/spaghetti/spaghetti-test2.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# spaghetti-test2.py
+#
+
+import os
+import sst
+
+
+s0 = sst.Component("s0", "spaghetti.Spaghetti")
+s0.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 100,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3131
+})
+
+s1 = sst.Component("s1", "spaghetti.Spaghetti")
+s1.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 100,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3731
+})
+
+
+for i in range(100):
+    linkX = sst.Link("link"+str(i))
+    linkX.connect( (s0, "port"+str(i), "1us"),
+                   (s1, "port"+str(i), "1us") )
+
+# EOF


### PR DESCRIPTION
This PR adds an entirely event-driven test component called `spaghetti`.  Spaghetti is a special version of the `noodle` component that operates without any explicit clock handlers.  All cross component messages are injected during the `setup` method.  Once the simulation starts, all the messages are sent across links using the prescribed latency delays.  Latency delays and TimeConverters are randomly generated for each message on each port.  This should force the explicit calculation of sync times across ranks and/or threads.

A few things to note:
- `numMsgs` indicates the number of messages per port.  The completion state (when the sim can end) is reached when the number of received messages is equal to: `numPorts x numMsgs`
- There are several tests in the tests directory for simple simulation setups
- The benchmarks directory contains a benchmark driver that will create large benchmark runs using an even number of ports and components connected in a ring.  50% of the ports are connected to the Nth-1 component, 50% to the to Nth+1 component.  

Parameters:
- verbose: Sets the verbosity level  [0]
- numPorts: Sets the number of ports  [2]
- numMsgs: Sets the number of messages per port to inject  [10]
- bytesPerMsg: Sets the number of bytes per msg  [64]
- rngSeed: Sets the RNG seed  [31337]