### PR TITLE
disallow "0Mhz" in getTimeConvertor to avoid FATAL error

### DIFF
--- a/sst-bench/spaghetti/spaghetti.cc
+++ b/sst-bench/spaghetti/spaghetti.cc
@@ -103,9 +103,11 @@ void Spaghetti::sendData(){
 
       // create random time bases and delays using our localRNG
       // time bases are restricted to three bits of precision, aka 7MHz
-      // delays are restrict to 8 bits of precision
-      TimeConverter tc = getTimeConverter(
-        std::to_string(localRNG->generateNextUInt32() & 0b111) + "MHz");
+      // delays are restrict to 8 bits of precision. 
+      // 0 MHz is illegal
+      uint32_t freq = localRNG->generateNextUInt32() & 0b111;
+      if (freq==0) freq=1;
+      TimeConverter tc = getTimeConverter(std::to_string(freq) + "MHz");
       SimTime_t delay = (SimTime_t)(localRNG->generateNextUInt32() & 0b11111111);
       linkHandlers[i]->send(delay, tc, se);
 


### PR DESCRIPTION
On Mac, the new `spaghetti` tests were failing with the following error:
```
FATAL:  SST Core: Error encountered during simulation: Error:  Attempting to get TimeConverter for a time (0 Hz) which is too large for the timebase (1 ps)
```

The root cause is that the random number selection can result in 0MHz which is checked in sst core.
```TimeConverter tc = getTimeConverter(std::to_string(localRNG->generateNextUInt32() & 0b111) + "MHz");```

The fix is simple but begs the question... why does this only fail (for me) on mac and not ubuntu.  There is a 1 in 8 chance of selecting 0, which seems pretty easy to hit.