### PR TITLE
adding statistics as a histogram to spaghetti component

### DIFF
--- a/components/spaghetti/spaghetti.cc
+++ b/components/spaghetti/spaghetti.cc
@@ -47,6 +47,12 @@ Spaghetti::Spaghetti(SST::ComponentId_t id, const SST::Params& params ) :
   // setup the local rand number generator
   localRNG = new SST::RNG::MersenneRNG(uint32_t(id) + rngSeed);
 
+  // initialize the statistics
+  for( uint64_t i= 0; i<numPorts; i++ ){
+    std::string pName = std::to_string(i);
+    LStat.push_back(registerStatistic<uint64_t>("LATENCY_PORT_", pName));
+  }
+
   // constructor complete
   output.verbose( CALL_INFO, 5, 0, "Constructor complete\n" );
 }
@@ -110,6 +116,7 @@ void Spaghetti::sendData(){
       TimeConverter tc = getTimeConverter(std::to_string(freq) + "MHz");
       SimTime_t delay = (SimTime_t)(localRNG->generateNextUInt32() & 0b11111111);
       linkHandlers[i]->send(delay, tc, se);
+      LStat[i]->addData(delay);
 
       output.verbose(CALL_INFO, 5, 0,
                      "%s: injected %zu byte message into port = %s\n",

--- a/components/spaghetti/spaghetti.h
+++ b/components/spaghetti/spaghetti.h
@@ -119,7 +119,9 @@ public:
   // -------------------------------------------------------
   // Spaghetti Component Statistics Data
   // -------------------------------------------------------
-  SST_ELI_DOCUMENT_STATISTICS()
+  SST_ELI_DOCUMENT_STATISTICS(
+    {"LATENCY_PORT_", "Histogram of latency values", "latency", 1},
+  )
 
   // -------------------------------------------------------
   // Spaghetti Component Checkpoint Methods
@@ -138,6 +140,7 @@ public:
     SST_SER(portname);
     SST_SER(linkHandlers);
     SST_SER(localRNG);
+    SST_SER(LStat);
   }
 
   /// Spaghetti: serialization implementations
@@ -159,6 +162,8 @@ private:
   std::vector<std::string> portname;              ///< port 0 to numPorts names
   std::vector<SST::Link *> linkHandlers;          ///< LinkHandler objects
   SST::RNG::Random* localRNG = 0;                 ///< component local random number generator
+
+  std::vector<Statistic<uint64_t>*> LStat;        ///< Statistics vector.  One entry per port.  Histogram of injection latencies
 
   // -- private methods
   /// Spaghetti: Message Event Handler

--- a/test/spaghetti/spaghetti-test3.py
+++ b/test/spaghetti/spaghetti-test3.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# spaghetti-test3.py
+#
+
+import os
+import sst
+
+sst.setStatisticLoadLevel(7)
+sst.setStatisticOutput("sst.statOutputCSV", {"filepath" : "./spaghetti-test3.csv",
+                                             "separator" : ", " } )
+
+s0 = sst.Component("s0", "spaghetti.Spaghetti")
+s0.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 100,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3131
+})
+
+s1 = sst.Component("s1", "spaghetti.Spaghetti")
+s1.addParams({
+  "verbose"      : 9,
+  "numPorts"     : 100,
+  "numMsgs"      : 100,
+  "bytesPerMsg"  : 64,
+  "rngSeed"      : 3731
+})
+
+
+for i in range(100):
+    linkX = sst.Link("link"+str(i))
+    linkX.connect( (s0, "port"+str(i), "1us"),
+                   (s1, "port"+str(i), "1us") )
+
+sst.enableAllStatisticsForComponentType("spaghetti.Spaghetti",
+                                        {"type":"sst.HistogramStatistic",
+                                        "minvalue" : "10",
+                                        "binwidth" : "10",
+                                        "numbins"  : "50",
+                                        "IncludeOutOfBounds" : "1"})
+
+# EOF


### PR DESCRIPTION
Adds a histogram statistics vector, one vector element per port, to track the injection latencies of messages.  This PR also adds a test to the test tree that outputs the histograms into 50 bins for downstream plotting 