### PR TITLE
parallel load script and new PLOAD sweeper sequence

### DIFF
--- a/benchmarks/noodle/parallel-load-local.sh
+++ b/benchmarks/noodle/parallel-load-local.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -x
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# parallel-load-local.sh
+#
+
+if [[ $(uname -o) =~ [Dd]arwin ]]; then
+    MPIOPTS=""
+else
+    MPIOPTS="--bind-to socket"
+fi
+
+CLOCKS=300000
+COM_OPTS="--print-timing-info=4"
+SST_OPTS="--output-config=config.py ../noodle-bench.py -- --verbose=0 --rngSeed=3131 --numComps=100 --portsPerComp=100 --msgPerClock=8 --bytesPerClock=4 --clocks=$CLOCKS"
+
+echo "########"
+echo "sst -n 8"
+echo "########"
+
+rm -rf sst-n8; mkdir sst-n8 || exit 1
+( cd sst-n8 && sst --num-threads=8 --parallel-output --run-mode=init ${COM_OPTS} ${SST_OPTS} | tee init.log ) || exit 1
+( cd sst-n8 && sst --num-threads=8 --parallel-load ${COM_OPTS} config.py | tee run.log ) || exit 1
+
+doit () {
+    NP=$1
+    N=$2
+    echo "########################"
+    echo "mpi ${MPIOPTS} -np ${NP} sst -n ${N}"
+    echo "########################"
+    DIR=mpi-np${NP}-n${N}
+    rm -rf $DIR; mkdir $DIR || exit 1
+    ( cd ${DIR} && mpirun $MPIOPTS -np $NP sst --num-threads=$N --parallel-output --run-mode=init ${COM_OPTS} ${SST_OPTS} | tee init.log ) || exit 1
+    ( cd ${DIR} && mpirun $MPIOPTS -np $NP sst --num-threads=$N --parallel-load ${COM_OPTS} config.py | tee run.log ) || exit 1
+}
+
+#   ranks threads/rank
+doit  8 1
+doit  1 8

--- a/benchmarks/noodle/parallel-load-slurm.sh
+++ b/benchmarks/noodle/parallel-load-slurm.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+export SLURM_CPU_BIND=verbose
+
+SCRIPTS=$(realpath ../../scripts) || exit 1
+
+CLOCKS=10000
+NUMCOMPS=16000
+ADDLIBPATH="--add-lib-path=$(realpath ../../components/noodle)" || exit 1
+SST_OPTS="${ADDLIBPATH} ${PWD}/noodle-bench.py -- --verbose=0 --rngSeed=3131 --numComps=$NUMCOMPS --portsPerComp=100 --msgPerClock=8 --bytesPerClock=4 --clocks=$CLOCKS"
+
+rm -rf tmpcfg
+mkdir -p tmpcfg || exit 1
+TMPCFG=$(realpath tmpcfg) || exit 1
+
+NODES=4
+RANKS=160
+THEADSPERRANK=1
+OCFG="${TMPCFG}/r${RANKS}t${THEADSPERRANK}_.py"
+
+sbatch --parsable --wait -N $NODES -n $RANKS -J para_init ${SCRIPTS}/perf.slurm -r ${SCRIPTS} -d ${PWD}/noodle.db -R ${PWD} sst --print-timing-info=4 --num-threads=$THEADSPERRANK --parallel-output --output-config=${OCFG} ${SST_OPTS}
+
+sbatch --parsable --wait -N $NODES -n $RANKS -J para_load ${SCRIPTS}/perf.slurm -r ${SCRIPTS} -d ${PWD}/noodle.db -R ${PWD} sst --print-timing-info-4 --num-threads=$THEADSPERRANK --parallel-load ${OCFG}

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -46,6 +46,30 @@
           "desc"     : "sweep 13 to 40 threads for a fixed configuration",
           "ranks"    : "1",
           "threadsPerRank" : "13,41,1"
+        },
+        { "name"     : "2to12_ranks_100to200_components",
+          "desc"     : "sweep 2 to 12 ranks, 100 to 200 components",
+          "ranks"    : "2,13,1",
+          "threadsPerRank" : "1",
+	  "sdl" : {
+	      "numComps" : "100,210,10"
+	  }
+        },
+        { "name"     : "13to40_ranks_100to200_components",
+          "desc"     : "sweep 13 to 40 ranks, 100 to 200 components",
+          "ranks"    : "13,41,1",
+          "threadsPerRank" : "1",
+	  "sdl" : {
+	      "numComps" : "100,210,10"
+	  }
+	},
+        { "name"     : "4nodes_4to40_ranks_1kto10k_components",
+          "desc"     : "sweep 4 to 40 ranks symmetrically across 4 nodes, 1000 to 10000 components",
+          "ranks"    : "4,44,4",
+          "threadsPerRank" : "1",
+	  "sdl" : {
+	      "numComps" : "1000,11000,1000"
+	  }
         }
     ]
  

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -2,7 +2,7 @@
     "job_sequencer" :
     {
         "seq"       : ["BASE", "Select simulation sequence: BASE|BASE_CPT|BASE_CPT_RST"],
-        "simperiod" : ["1000", "checkpoint sim period in ns used with BASE_CPT_* sequences"]
+        "simperiod" : ["20000","checkpoint sim period in ns used with BASE_CPT_* sequences"]
     },
     "sim_controls"  :
     {
@@ -22,7 +22,7 @@
         "portsPerComp"  : ["100",     "Number of ports per component"],
         "msgPerClock"   : ["8",       "Messages per clock cycle"],
         "bytesPerClock" : ["4",       "Bytes per clock"],
-        "clocks"        : ["1000000", "[REQUIRED] Number of clocks to run sim"],
+        "clocks"        : ["100000", "[REQUIRED] Number of clocks to run sim"],
         "rngSeed"       : ["3131",    "Random number generator seed"]
     },
     "sweeps" :

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -55,6 +55,14 @@
               "numComps" : "100,210,10"
           }
         },
+        { "name"     : "2to12_threads_100to200_components",
+          "desc"     : "sweep 2 to 12 threads, 100 to 200 components",
+          "ranks"    : "1",
+          "threadsPerRank" : "2,13,1",
+          "sdl" : {
+              "numComps" : "100,210,10"
+          }
+        },
         { "name"     : "13to40_ranks_100to200_components",
           "desc"     : "sweep 13 to 40 ranks, 100 to 200 components",
           "ranks"    : "13,41,1",
@@ -62,13 +70,29 @@
           "sdl" : {
               "numComps" : "100,210,10"
           }
-	      },
-        { "name"     : "4nodes_4to40_ranks_1kto10k_components",
-          "desc"     : "sweep 4 to 40 ranks symmetrically across 4 nodes, 1000 to 10000 components",
-          "ranks"    : "4,44,4",
+	},
+        { "name"     : "13to40_threads_100to200_components",
+          "desc"     : "sweep 13 to 40 threads, 100 to 200 components",
+          "ranks"    : "1",
+          "threadsPerRank" : "13,41,1",
+          "sdl" : {
+              "numComps" : "100,210,10"
+          }
+	},
+        { "name"     : "4nodes_12to40_ranks_per_node_200to500_components",
+          "desc"     : "sweep 12 to 40 ranks symmetrically across 4 nodes, 200 to 500 components",
+          "ranks"    : "12,164,4",
           "threadsPerRank" : "1",
           "sdl" : {
-              "numComps" : "1000,11000,1000"
+              "numComps" : "200,600,100"
+          }
+        },
+        { "name"     : "4nodes_12to40_threads_per_node_200to500_components",
+          "desc"     : "sweep 12 to 40 threads symmetrically across 4 nodes, 200 to 500 components",
+          "ranks"    : "1",
+          "threadsPerRank" : "12,164,4",
+          "sdl" : {
+              "numComps" : "200,600,100"
           }
         }
     ]

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -47,6 +47,30 @@
           "ranks"    : "1",
           "threadsPerRank" : "13,41,1"
         },
+        { "name"     : "weak_scaling_1to12_ranks",
+          "desc"     : "sweep 1 to 12 ranks for a fixed configuration, x tied to ranks/threads",
+          "ranks"    : "1,13,1",
+          "threadsPerRank" : "1",
+	        "depvar"   : "numComps"
+        },
+        { "name"     : "weak_scaling_1to12_threads",
+          "desc"     : "sweep 1 to 12 threads for a fixed configuration, x tied to ranks/threads",
+          "ranks"    : "1",
+          "threadsPerRank" : "1,13,1",
+	        "depvar"   : "numComps"
+        },
+        { "name"     : "weak_scaling_13to40_ranks",
+          "desc"     : "sweep 13 to 40 ranks for a fixed configuration, x tied to ranks/threads",
+          "ranks"    : "13,41,1",
+          "threadsPerRank" : "1",
+	        "depvar"   : "numComps"
+        },
+        { "name"     : "weak_scaling_13to40_threads",
+          "desc"     : "sweep 13 to 40 threads for a fixed configuration, x tied to ranks/threads",
+          "ranks"    : "1",
+          "threadsPerRank" : "13,41,1",
+	        "depvar"   : "numComps"
+        },
         { "name"     : "2to12_ranks_100to200_components",
           "desc"     : "sweep 2 to 12 ranks, 100 to 200 components",
           "ranks"    : "2,13,1",
@@ -70,7 +94,7 @@
           "sdl" : {
               "numComps" : "100,210,10"
           }
-	},
+	      },
         { "name"     : "13to40_threads_100to200_components",
           "desc"     : "sweep 13 to 40 threads, 100 to 200 components",
           "ranks"    : "1",
@@ -78,7 +102,7 @@
           "sdl" : {
               "numComps" : "100,210,10"
           }
-	},
+	      },
         { "name"     : "4nodes_12to40_ranks_per_node_200to500_components",
           "desc"     : "sweep 12 to 40 ranks symmetrically across 4 nodes, 200 to 500 components",
           "ranks"    : "12,164,4",

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -51,25 +51,25 @@
           "desc"     : "sweep 2 to 12 ranks, 100 to 200 components",
           "ranks"    : "2,13,1",
           "threadsPerRank" : "1",
-	  "sdl" : {
-	      "numComps" : "100,210,10"
-	  }
+          "sdl" : {
+              "numComps" : "100,210,10"
+          }
         },
         { "name"     : "13to40_ranks_100to200_components",
           "desc"     : "sweep 13 to 40 ranks, 100 to 200 components",
           "ranks"    : "13,41,1",
           "threadsPerRank" : "1",
-	  "sdl" : {
-	      "numComps" : "100,210,10"
-	  }
-	},
+          "sdl" : {
+              "numComps" : "100,210,10"
+          }
+	      },
         { "name"     : "4nodes_4to40_ranks_1kto10k_components",
           "desc"     : "sweep 4 to 40 ranks symmetrically across 4 nodes, 1000 to 10000 components",
           "ranks"    : "4,44,4",
           "threadsPerRank" : "1",
-	  "sdl" : {
-	      "numComps" : "1000,11000,1000"
-	  }
+          "sdl" : {
+              "numComps" : "1000,11000,1000"
+          }
         }
     ]
  

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -51,25 +51,25 @@
           "desc"     : "sweep 1 to 12 ranks for a fixed configuration, x tied to ranks/threads",
           "ranks"    : "1,13,1",
           "threadsPerRank" : "1",
-	        "depvar"   : "numComps"
+          "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_1to12_threads",
           "desc"     : "sweep 1 to 12 threads for a fixed configuration, x tied to ranks/threads",
           "ranks"    : "1",
           "threadsPerRank" : "1,13,1",
-	        "depvar"   : "numComps"
+          "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_13to40_ranks",
           "desc"     : "sweep 13 to 40 ranks for a fixed configuration, x tied to ranks/threads",
           "ranks"    : "13,41,1",
           "threadsPerRank" : "1",
-	        "depvar"   : "numComps"
+          "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_13to40_threads",
           "desc"     : "sweep 13 to 40 threads for a fixed configuration, x tied to ranks/threads",
           "ranks"    : "1",
           "threadsPerRank" : "13,41,1",
-	        "depvar"   : "numComps"
+          "depvar"   : "numComps"
         },
         { "name"     : "2to12_ranks_100to200_components",
           "desc"     : "sweep 2 to 12 ranks, 100 to 200 components",
@@ -94,7 +94,7 @@
           "sdl" : {
               "numComps" : "100,210,10"
           }
-	      },
+        },
         { "name"     : "13to40_threads_100to200_components",
           "desc"     : "sweep 13 to 40 threads, 100 to 200 components",
           "ranks"    : "1",
@@ -102,7 +102,7 @@
           "sdl" : {
               "numComps" : "100,210,10"
           }
-	      },
+        },
         { "name"     : "4nodes_12to40_ranks_per_node_200to500_components",
           "desc"     : "sweep 12 to 40 ranks symmetrically across 4 nodes, 200 to 500 components",
           "ranks"    : "12,164,4",

--- a/benchmarks/noodle/perf-sweeps.json
+++ b/benchmarks/noodle/perf-sweeps.json
@@ -47,28 +47,50 @@
           "ranks"    : "1",
           "threadsPerRank" : "13,41,1"
         },
+        { "name"     : "strong_scaling_4nodes_12to40_ranks_per_node",
+          "desc"     : "sweep 13 to 40 ranks per node for a fixed configuration",
+          "ranks"    : "12,164,4",
+          "threadsPerRank" : "1"
+        },
+        { "name"     : "strong_scaling_4_nodes_13to40_threads_per_node",
+          "desc"     : "sweep 12 to 40 threads per node for a fixed configuration",
+          "ranks"    : "1",
+          "threadsPerRank" : "12,164,4"
+        },
         { "name"     : "weak_scaling_1to12_ranks",
-          "desc"     : "sweep 1 to 12 ranks for a fixed configuration, x tied to ranks/threads",
+          "desc"     : "sweep 1 to 12 ranks for a fixed configuration, numComps tied to ranks/threads",
           "ranks"    : "1,13,1",
           "threadsPerRank" : "1",
           "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_1to12_threads",
-          "desc"     : "sweep 1 to 12 threads for a fixed configuration, x tied to ranks/threads",
+          "desc"     : "sweep 1 to 12 threads for a fixed configuration, numComps tied to ranks/threads",
           "ranks"    : "1",
           "threadsPerRank" : "1,13,1",
           "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_13to40_ranks",
-          "desc"     : "sweep 13 to 40 ranks for a fixed configuration, x tied to ranks/threads",
+          "desc"     : "sweep 13 to 40 ranks for a fixed configuration, numComps tied to ranks/threads",
           "ranks"    : "13,41,1",
           "threadsPerRank" : "1",
           "depvar"   : "numComps"
         },
         { "name"     : "weak_scaling_13to40_threads",
-          "desc"     : "sweep 13 to 40 threads for a fixed configuration, x tied to ranks/threads",
+          "desc"     : "sweep 13 to 40 threads for a fixed configuration, numComps tied to ranks/threads",
           "ranks"    : "1",
           "threadsPerRank" : "13,41,1",
+          "depvar"   : "numComps"
+        },
+        { "name"     : "weak_scaling_4nodes_12to40_ranks_per_node",
+          "desc"     : "sweep 13 to 40 ranks for a fixed configuration, numComps tied to ranks/threads",
+          "ranks"    : "112,164,4",
+          "threadsPerRank" : "1",
+          "depvar"   : "numComps"
+        },
+        { "name"     : "weak_scaling_4nodes_12to40_threads_per_node",
+          "desc"     : "sweep 13 to 40 threads for a fixed configuration, numComps tied to ranks/threads",
+          "ranks"    : "1",
+          "threadsPerRank" : "12,164,4",
           "depvar"   : "numComps"
         },
         { "name"     : "2to12_ranks_100to200_components",
@@ -103,20 +125,20 @@
               "numComps" : "100,210,10"
           }
         },
-        { "name"     : "4nodes_12to40_ranks_per_node_200to500_components",
-          "desc"     : "sweep 12 to 40 ranks symmetrically across 4 nodes, 200 to 500 components",
+        { "name"     : "4nodes_12to40_ranks_per_node_100to200_components",
+          "desc"     : "sweep 12 to 40 ranks symmetrically across 4 nodes, 100 to 200 components",
           "ranks"    : "12,164,4",
           "threadsPerRank" : "1",
           "sdl" : {
-              "numComps" : "200,600,100"
+              "numComps" : "100,210,10"
           }
         },
-        { "name"     : "4nodes_12to40_threads_per_node_200to500_components",
-          "desc"     : "sweep 12 to 40 threads symmetrically across 4 nodes, 200 to 500 components",
+        { "name"     : "4nodes_12to40_threads_per_node_100to200_components",
+          "desc"     : "sweep 12 to 40 threads symmetrically across 4 nodes, 100 to 200 components",
           "ranks"    : "1",
           "threadsPerRank" : "12,164,4",
           "sdl" : {
-              "numComps" : "200,600,100"
+              "numComps" : "100,210,10"
           }
         }
     ]

--- a/benchmarks/noodle/run-sweeps-local.sh
+++ b/benchmarks/noodle/run-sweeps-local.sh
@@ -18,24 +18,26 @@ OPTS="--noprompt $1"
 
 # uncomment desired sequence
 # OPTS+=" --seq=BASE"
-# OPTS+=" --seq=BASE_CPT"
+OPTS+=" --seq=BASE_CPT"
 # OPTS+=" --seq=BASE_CPT_RST"
-OPTS+=" --seq=BASE_PLOAD"
+# OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run
 do_strong_scaling=true
-do_parallel_loads=true
+do_component_sweeps=true
 
 if [[ $do_strong_scaling ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
 fi
 
-if [[ $do_parallel_loads ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components ${OPTS}
+if [[ $do_component_sweeps ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_threads_100to200_components --jobname="c100t13" ${OPTS}
 fi
 
 # simple sql script to extract some good info

--- a/benchmarks/noodle/run-sweeps-local.sh
+++ b/benchmarks/noodle/run-sweeps-local.sh
@@ -6,7 +6,7 @@
 #
 # See LICENSE in the top level directory for licensing details
 
-# This simulation use mpirun to launch simulations locally
+# These sweeps use mpirun to manage simulations locally
 
 # usage:   ./run-sweeps-local.sh [sst-sweeper options]
 # example: ./run-sweeps-local.sh --norun
@@ -15,10 +15,28 @@
 mkdir -p jobs || exit 1
 
 OPTS="--noprompt $1"
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks ${OPTS}
+
+# uncomment desired sequence
+# OPTS+=" --seq=BASE"
+# OPTS+=" --seq=BASE_CPT"
+# OPTS+=" --seq=BASE_CPT_RST"
+OPTS+=" --seq=BASE_PLOAD"
+
+# edit these to select which groups to run
+do_strong_scaling=true
+do_parallel_loads=true
+
+if [[ $do_strong_scaling ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   ${OPTS}
+fi
+
+if [[ $do_parallel_loads ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components ${OPTS}
+fi
 
 # simple sql script to extract some good info
 cat << EOF > noodle.sql

--- a/benchmarks/noodle/run-sweeps-local.sh
+++ b/benchmarks/noodle/run-sweeps-local.sh
@@ -34,11 +34,12 @@ if [[ $do_strong_scaling == true ]]; then
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
 fi
 
+# Beware: The build time grows expontially with numComps. These will instantiate numComps * ranks * threads
 if [[ $do_weak_scaling == true ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_ranks    --jobname="ws1r" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_threads --jobname="ws13t" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_ranks   --jobname="ws13r" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t"  --numComps=10 ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_ranks    --jobname="ws1r"  --numComps=10 ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_threads --jobname="ws13t" --numComps=10 ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_ranks   --jobname="ws13r" --numComps=10 ${OPTS}
 fi
 
 # These take a VERY long time

--- a/benchmarks/noodle/run-sweeps-local.sh
+++ b/benchmarks/noodle/run-sweeps-local.sh
@@ -23,17 +23,26 @@ OPTS+=" --seq=BASE_CPT_RST"
 # OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run
-do_strong_scaling=true
-do_component_sweeps=true
+do_strong_scaling=false
+do_weak_scaling=true
+do_component_sweeps=false
 
-if [[ $do_strong_scaling ]]; then
+if [[ $do_strong_scaling == true ]]; then
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
 fi
 
-if [[ $do_component_sweeps ]]; then
+if [[ $do_weak_scaling == true ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_ranks    --jobname="ws1r" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_threads --jobname="ws13t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_ranks   --jobname="ws13r" ${OPTS}
+fi
+
+# These take a VERY long time
+if [[ $do_component_sweeps == true ]]; then
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}

--- a/benchmarks/noodle/run-sweeps-local.sh
+++ b/benchmarks/noodle/run-sweeps-local.sh
@@ -18,8 +18,8 @@ OPTS="--noprompt $1"
 
 # uncomment desired sequence
 # OPTS+=" --seq=BASE"
-OPTS+=" --seq=BASE_CPT"
-# OPTS+=" --seq=BASE_CPT_RST"
+#OPTS+=" --seq=BASE_CPT"
+OPTS+=" --seq=BASE_CPT_RST"
 # OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -18,13 +18,13 @@ OPTS="--noprompt --slurm $1"
 
 # uncomment desired sequence
 # OPTS+=" --seq=BASE"
-# OPTS+=" --seq=BASE_CPT"
-# OPTS+=" --seq=BASE_CPT_RST"
-OPTS+=" --seq=BASE_PLOAD"
+#OPTS+=" --seq=BASE_CPT"
+OPTS+=" --seq=BASE_CPT_RST"
+# OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run
 do_strong_scaling=true
-do_component_sweeps=true=true
+do_component_sweeps=true
 
 if [[ $do_strong_scaling ]]; then
   ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -6,7 +6,7 @@
 #
 # See LICENSE in the top level directory for licensing details
 
-# These simulations utilize sbatch to launch simulations
+# These sweeps utilize sbatch to manage simulations using slurm
 
 # usage:   ./run-sweeps-slurm.sh [sst-sweeper options]
 # example: ./run-sweeps-slurm.sh --norun
@@ -15,10 +15,29 @@
 mkdir -p jobs || exit 1
 
 OPTS="--noprompt --slurm $1"
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
-${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   ${OPTS}
+
+# uncomment desired sequence
+# OPTS+=" --seq=BASE"
+# OPTS+=" --seq=BASE_CPT"
+# OPTS+=" --seq=BASE_CPT_RST"
+OPTS+=" --seq=BASE_PLOAD"
+
+# edit these to select which groups to run
+do_strong_scaling=true
+do_parallel_loads=true
+
+if [[ $do_strong_scaling ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   ${OPTS}
+fi
+
+if [[ $do_parallel_loads ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_4to40_ranks_1kto10k_components ${OPTS}
+fi
 
 # simple sql script to extract some good info
 cat << EOF > noodle.sql

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -35,7 +35,7 @@ if [[ $do_strong_scaling ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 --nodeclamp=4 ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 --nodeclamp=4 ${OPTS}
   fi
-  if [[ $do_1node_sweeps ]]; then
+  if [[ $do_1node_sweeps == true ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
@@ -49,7 +49,7 @@ if [[ $do_weak_scaling == true ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 --nodeclamp=4 ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 --nodeclamp=4 ${OPTS}
   fi
-  if [[ $do_1node_sweeps ]]; then
+  if [[ $do_1node_sweeps == true ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t"  --numComps=10 ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_ranks    --jobname="ws1r"  --numComps=10 ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_threads --jobname="ws13t" --numComps=10 ${OPTS}
@@ -63,7 +63,7 @@ if [[ $do_component_sweeps == true ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_100to200_components   --jobname="n4c100r12" --nodeclamp=4 ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_100to200_components --jobname="n4c100t12" --nodeclamp=4 ${OPTS}
   fi
-  if [[ $do_1node_sweeps ]]; then
+  if [[ $do_1node_sweeps == true ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -32,8 +32,8 @@ do_component_sweeps=true
 
 if [[ $do_strong_scaling ]]; then
   if [[ $do_4node_sweeps == true ]]; then
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 ${OPTS}
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 --nodeclamp=4 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 --nodeclamp=4 ${OPTS}
   fi
   if [[ $do_1node_sweeps ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
@@ -46,8 +46,8 @@ fi
 # Beware: The build time grows expontially with numComps. These will instantiate numComps * ranks * threads
 if [[ $do_weak_scaling == true ]]; then
   if [[ $do_4node_sweeps == true ]]; then
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 ${OPTS}
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 --nodeclamp=4 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 --nodeclamp=4 ${OPTS}
   fi
   if [[ $do_1node_sweeps ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t"  --numComps=10 ${OPTS}
@@ -60,8 +60,8 @@ fi
 # These take a VERY long time
 if [[ $do_component_sweeps == true ]]; then
   if [[ $do_4node_sweeps == true ]]; then
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_100to200_components   --jobname="n4c100r12" ${OPTS}
-    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_100to200_components --jobname="n4c100t12" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_100to200_components   --jobname="n4c100r12" --nodeclamp=4 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_100to200_components --jobname="n4c100t12" --nodeclamp=4 ${OPTS}
   fi
   if [[ $do_1node_sweeps ]]; then
     ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -24,19 +24,22 @@ OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run
 do_strong_scaling=true
-do_parallel_loads=true
+do_component_sweeps=true=true
 
 if [[ $do_strong_scaling ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
 fi
 
-if [[ $do_parallel_loads ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_4to40_ranks_1kto10k_components ${OPTS}
+if [[ $do_component_sweeps ]]; then
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_threads_100to200_components --jobname="c100t13" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_200to500_components   --jobname="n4c200r12" ${OPTS}
+  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_200to500_components --jobname="n4c200t12" ${OPTS}
 fi
 
 # simple sql script to extract some good info
@@ -54,7 +57,7 @@ LEFT JOIN
   sdl_info    S ON S.jobid = J.jobid
 LEFT JOIN
   timing_info T ON T.jobid = J.jobid
-WHERE J.jobtype == 'BASE'
+WHERE J.jobtype != 'COMPLETION'
 
 EOF
 

--- a/benchmarks/noodle/run-sweeps-slurm.sh
+++ b/benchmarks/noodle/run-sweeps-slurm.sh
@@ -23,23 +23,52 @@ OPTS+=" --seq=BASE_CPT_RST"
 # OPTS+=" --seq=BASE_PLOAD"
 
 # edit these to select which groups to run
+do_4node_sweeps=true
+do_1node_sweeps=false
+
 do_strong_scaling=true
+do_weak_scaling=true
 do_component_sweeps=true
 
 if [[ $do_strong_scaling ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
+  if [[ $do_4node_sweeps == true ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 ${OPTS}
+  fi
+  if [[ $do_1node_sweeps ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_threads  --jobname="ss1t" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_1to12_ranks    --jobname="ss1r" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_threads --jobname="ss13t" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py strong_scaling_13to40_ranks   --jobname="ss13r" ${OPTS}
+  fi
 fi
 
-if [[ $do_component_sweeps ]]; then
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_threads_100to200_components --jobname="c100t13" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_200to500_components   --jobname="n4c200r12" ${OPTS}
-  ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_200to500_components --jobname="n4c200t12" ${OPTS}
+# Beware: The build time grows expontially with numComps. These will instantiate numComps * ranks * threads
+if [[ $do_weak_scaling == true ]]; then
+  if [[ $do_4node_sweeps == true ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_threads_per_node --jobname="wsn4t12" --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_4nodes_12to40_ranks_per_node   --jobname="wsn4r12" --numComps=10 ${OPTS}
+  fi
+  if [[ $do_1node_sweeps ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_threads  --jobname="ws1t"  --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_1to12_ranks    --jobname="ws1r"  --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_threads --jobname="ws13t" --numComps=10 ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py weak_scaling_13to40_ranks   --jobname="ws13r" --numComps=10 ${OPTS}
+  fi
+fi
+
+# These take a VERY long time
+if [[ $do_component_sweeps == true ]]; then
+  if [[ $do_4node_sweeps == true ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_ranks_per_node_100to200_components   --jobname="n4c100r12" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 4nodes_12to40_threads_per_node_100to200_components --jobname="n4c100t12" ${OPTS}
+  fi
+  if [[ $do_1node_sweeps ]]; then
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_ranks_100to200_components   --jobname="c100r2" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 2to12_threads_100to200_components --jobname="c100t2" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_ranks_100to200_components   --jobname="c100r13" ${OPTS}
+    ${SST_BENCH_HOME}/scripts/sst-sweeper.py ./perf-sweeps.json ./noodle-bench.py 13to40_threads_100to200_components --jobname="c100t13" ${OPTS}
+  fi
 fi
 
 # simple sql script to extract some good info

--- a/scripts/sqlutils.py
+++ b/scripts/sqlutils.py
@@ -52,6 +52,7 @@ sdlInfoTable = "sdl_info"
 # all tables have implied 'jobid' as unique primary key
 keyDict = {
     jobInfoTable : [
+        "jobname",   # string used to identify job grouping
         "friend",    # related simulation ( e.g. base simulation id for checkpoint sim comparison)
         "jobtype",   # BASE, CPT, RST, COMPLETION
         "jobstring", # command line

--- a/scripts/sst-sweeper.py
+++ b/scripts/sst-sweeper.py
@@ -34,8 +34,6 @@ g_pfx = "[sst-sweeper.py]"
 g_scripts = os.path.dirname(os.path.abspath(sys.argv[0]))
 g_slurm_script = os.path.abspath(f"{g_scripts}/perf.slurm")
 g_slurm_completion = os.path.abspath(f"{g_scripts}/completion.slurm")
-g_scratchdir = os.path.abspath(".")
-g_tmpdir = g_scratchdir
 g_cptpfx = "_cpt"
 g_start_time = datetime.now()
 g_id_base = (int(datetime.timestamp(datetime.now())*10) & 0xffffff) << 16
@@ -60,14 +58,8 @@ class JobType(Enum):
     BASE = 1
     CPT  = 2
     RST  = 3
-    COMPLETION = 4
-
-# if scratch directory exists create a jobs directory
-if not os.path.isdir(g_tmpdir):
-    if os.path.isdir(g_scratchdir):
-        os.mkdir(g_tmpdir)
-    else:
-        g_tmpdir = "."
+    PLOAD = 4
+    COMPLETION = 99
 
 def is_integer(s: str) -> bool:
     try:
@@ -110,6 +102,7 @@ class JobEntry():
         self.procs = ranks * threads
         self.sst_params = copy(sst_params)
         self.sdl_params = copy(sdl_params)
+        self.sim_controls = copy(sim_control_params)
 
         self.slurm = options['slurm']
         self.db = sim_controls['db']
@@ -123,8 +116,10 @@ class JobEntry():
         self.cpt_timestamp = 0
         self.setdeps = False
 
-        self.sstopts = f"--num-threads={self.threads} --output-json=config.json"
-        self.sstopts += f" --print-timing-info --timing-info-json=timing.json"
+        self.sstopts = f"--num-threads={self.threads}"
+        self.sstopts += f" --print-timing-info=4 --timing-info-json=timing.json"
+        self.sstopts += " --output-config=config.py --parallel-output"
+        # --output-json=config.json" 
         for opt in sst_params:
             self.sstopts += f" --{opt}={sst_params[opt]}"
         
@@ -171,6 +166,13 @@ class JobEntry():
         self.cpt_num = cpt_num
         self.cpt_timestamp = cpt_timestamp
         self.setdeps = True
+    def pload(self, baseid):
+        self.jtype = JobType.PLOAD
+        self.sstopts += f" --parallel-load"
+        self.sdlFile = ""
+        self.friend = baseid
+        self.predecessors = [ baseid ]
+        self.setdeps = True
     def completion(self):
         self.jtype = JobType.COMPLETION
     def getsid(self, slurm, lid, norun):
@@ -183,12 +185,18 @@ class JobEntry():
     def getJobString(self, norun = False):
         # only called when submitting runs to ensure previous slurm ids are available
         if self.jtype == JobType.COMPLETION:
-            jobstring = f"{g_sbatch} --parsable --wait --dependency=singleton --job-name={self.jobname} {g_slurm_completion} -r {g_scripts} -R {g_tmpdir} -d {self.db}"
+            jobstring = f"{g_sbatch} --parsable --wait --dependency=singleton --job-name={self.jobname} {g_slurm_completion} -r {g_scripts} -R {self.sim_controls['tmpdir']} -d {self.db}"
             return jobstring
+        # Parallel load
+        if self.jtype == JobType.PLOAD:
+            sid = self.getsid(self.slurm, self.friend, norun)
+            self.sstopts += f" ../{sid}/config.py"
+        # Restart
         if self.jtype == JobType.RST:
             sid = self.getsid(self.slurm, self.cptid, norun)
             self.sstopts += f" --load-checkpoint ../{sid}/{self.cptfile}"
         sst_cmd = f"sst {self.sdlFile} {self.sstopts} {self.sdlopts}"
+        # Set dependencies
         if self.slurm == False:
             # local jobs will not be run in parallel so dependencies do not matter
             jobstring = f"{g_mpirun} -np {self.ranks} {sst_cmd}"
@@ -199,7 +207,7 @@ class JobEntry():
                 for lid in self.predecessors:
                     deps += f":{self.getsid(True, lid, norun)}"
             wait = "--wait"  # TODO this should be optional
-            jobstring = f"{g_sbatch} --parsable {wait} {deps} -N {self.nodes} -n {self.ranks} -J {self.jobname} {g_slurm_script} -r {g_scripts} -d {self.db} -R {g_tmpdir} {sst_cmd}"
+            jobstring = f"{g_sbatch} --parsable {wait} {deps} -N {self.nodes} -n {self.ranks} -J {self.jobname} {g_slurm_script} -r {g_scripts} -d {self.db} -R {self.sim_controls['tmpdir']} {sst_cmd}"
         return jobstring
 
 class JobManager():
@@ -220,6 +228,7 @@ class JobManager():
         seq = job_sequencer_params['seq']
         self.do_restart = seq=='BASE_CPT_RST'
         self.do_checkpoint = seq=='BASE_CPT' or self.do_restart
+        self.do_parallel_load = seq=='BASE_PLOAD'
         self.simperiod = int(job_sequencer_params['simperiod'])
 
         self.sst_params = copy(sst_params)
@@ -251,6 +260,7 @@ class JobManager():
     def add_job_sequence(self, baseEntry:JobEntry):
         # base sim
         id_base = jobmgr.add_job(baseEntry)
+        # add checkpoint job
         if self.do_checkpoint:
             cptEntry=copy(baseEntry)
             cptEntry.cpt(self.simperiod, id_base)
@@ -259,6 +269,7 @@ class JobManager():
             numCpts = int(clocks / self.simperiod)
             period = int(self.simperiod * 1000) # ns to ps
             timestamp = (numCpts+1) * period
+            # add restart jobs
             if self.do_restart:
                 # schedule shortest restart runs first 
                 for n in range(numCpts, 0, -1):
@@ -267,6 +278,11 @@ class JobManager():
                     rstEntry = copy(baseEntry)
                     rstEntry.rst(id_cpt, cpt, n, timestamp)
                     jobmgr.add_job(rstEntry)
+        # add parallel load job
+        if self.do_parallel_load:
+            ploadEntry=copy(baseEntry)
+            ploadEntry.pload(id_base)
+            jobmgr.add_job(ploadEntry)
         # slurm completion creates barrier and can perform post-processing
         if self.slurm:
             compEntry=copy(baseEntry)
@@ -341,7 +357,7 @@ class JobManager():
         if g_sacct != None:
             for id in self.wipList:
                 if id != comp_id:
-                    rundir=f"{g_tmpdir}/{self.jobname}/{id}"
+                    rundir=f"{self.tmpdir}/{self.jobname}/{id}"
                     cmd=f"sacct -l -j {id} --json"
                     self.jutil.exec(cmd=cmd, cwd=rundir, log="slurm.json")
                     self.sqldb.slurm_info(jobid=id, jobpath=rundir)
@@ -467,9 +483,9 @@ class JsonParams():
         return len(self.errors) > 0
     def error_string(self) -> str:
         return f"Please fix json errors in {self.abspath}:\n" + '\n'.join(self.errors)
-    def defv_str(self, group, key) -> str:
+    def defv_str(self, group, key, dflt="") -> str:
         if self.json == None:
-            return ""
+            return dflt
         if group in self.json:
             if key in self.json[group]:
                 if len(self.json[group][key])==2:
@@ -533,7 +549,7 @@ if __name__ == '__main__':
 
     # "job_sequencer" overrides
     job_seq_group = parser.add_argument_group('job sequencer overrides')
-    ALLOWED_SEQ = ['BASE', 'BASE_CPT', 'BASE_CPT_RST']
+    ALLOWED_SEQ = ['BASE', 'BASE_CPT', 'BASE_CPT_RST', 'BASE_PLOAD']
     job_seq_group.add_argument("--seq", type=str, choices=ALLOWED_SEQ,
                                help=f"Select simulation sequence {jsonParams.defv_str('job_sequencer', 'seq')}")
     job_seq_group.add_argument("--simperiod", type=int, 
@@ -546,7 +562,7 @@ if __name__ == '__main__':
     sim_ctl_group.add_argument("--jobname", type=str,
                                help=f"name associated with all jobs {jsonParams.defv_str('sim_controls', 'jobname')}")
     sim_ctl_group.add_argument("--tmpdir", type=str,
-                               help=f"temporary area for running jobs {jsonParams.defv_str('sim_controls', 'tmpdir')}")
+                               help=f"temporary area for running jobs {jsonParams.defv_str('sim_controls', 'tmpdir', '[./]')}")
     sim_ctl_group.add_argument("--nodeclamp", type=int,
                                help=f"distribute threads evenly across specified nodes {jsonParams.defv_str('sim_controls', 'nodeclamp')}")
 
@@ -689,8 +705,10 @@ if __name__ == '__main__':
             print("error: simperiod must be greater than clocks")
             sys.exit(1)
     # confirm temporary directory exists
-    if not os.path.isdir(sim_control_params['tmpdir']):
-        print(f"error: could not locate tmpdir: {sim_control_params['tmpdir']}")
+    try:
+        os.makedirs(sim_control_params['tmpdir'], exist_ok=True)
+    except OSError as e:
+        print(f"error: could not create tmpdir: {sim_control_params['tmpdir']}")
         sys.exit(1)
     # confirm timing.db containing directory exists
     dirname = os.path.dirname(sim_control_params['db'])

--- a/scripts/sst-sweeper.py
+++ b/scripts/sst-sweeper.py
@@ -726,7 +726,7 @@ if __name__ == '__main__':
         else:
             depvar_base_value = int(sdl_params[depvar])
             print(f"\nFound SDL dependent variable, '{depvar}', with base value={depvar_base_value}")
-            print(f"{depvar} will be resolved as {depvar_base_value} * (ranks + threads)")
+            print(f"{depvar} will be resolved as {depvar_base_value} * (ranks * threads)")
     # SDL sweep variable check
     sdl_sweep_params = None
     sdl_sweep_var = None
@@ -784,7 +784,7 @@ if __name__ == '__main__':
                 if sdl_sweep_var:
                     local_sdl_params[sdl_sweep_var] = s
                 if depvar:
-                    local_sdl_params[depvar] = depvar_base_value * ( r + t )
+                    local_sdl_params[depvar] = depvar_base_value * ( r * t )
                 jobmgr.add_job_sequence(JobEntry(
                     sdlFile=sdlFile,
                     options=options,

--- a/scripts/sst-sweeper.py
+++ b/scripts/sst-sweeper.py
@@ -325,6 +325,7 @@ class JobManager():
             self.pp_remote(comp_id=jobid)
 
         self.sqldb.job_info( jobid=jobid, dataDict={
+            "jobname": entry.jobname,
             "friend": friend,
             "jobtype": entry.jtype.name, 
             "jobstring": jobstr, 


### PR DESCRIPTION
This PR adds sweep automation for measuring parallel loading performance using the sst-sweeper.py parameter `--seq=BASE_PLOAD`.  This will run a baseline simulation, save the configuration using `--parallel-output` and then run a simulation where that configuration is loaded using  `--parallel-load=config.py`.  As always, this supports both local mpirun simulations and sbatch simulation under slurm.

For noodle, the `perf-sweep.json` file now includes sweeps that include ranks, threads, and component counts. There are also 2 scripts that run single parallel load jobs.

Items to complete before pushing:
- Finish testing local and slurm sweeps.
- Update the `run-sweeps-*.sh` scripts to include the new sweeps.
