### PR TITLE
qualifying hpe-phold test inclusion with sst-core mpi configured

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ execute_process(COMMAND sst-config --prefix
                 OUTPUT_VARIABLE SST_INSTALL_DIR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+execute_process(COMMAND sst-config --MPICC
+                OUTPUT_VARIABLE SST_MPICC
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 set(SST_INCLUDE_DIR "${SST_INSTALL_DIR}/include")
 if(NOT (EXISTS "${SST_INSTALL_DIR}"))
   message(FATAL_ERROR " SST_INSTALL_DIR (${SST_INSTALL_DIR}) is invalid.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,8 +37,10 @@ if( (${SST_VERSION} STREQUAL "DEV") OR (${SST_VERSION} VERSION_GREATER_EQUAL "15
   message(STATUS "[SST-BENCH] Enabling SPAGHETTI testing")
   add_subdirectory(noodle)
   add_subdirectory(spaghetti)
-  message(STATUS "[SST-BENCH] Enabling HPE-PHOLD testing")
-  add_subdirectory(hpe-phold)
+  if( ${SST_MPICC} MATCHES ".*mpi.*" )
+    message(STATUS "[SST-BENCH] Enabling HPE-PHOLD testing")
+    add_subdirectory(hpe-phold)
+  endif()
 endif()
 
 # TODO replace with interactive console micro-benchmarks


### PR DESCRIPTION
This PR is a baby step towards managing tests based on whether or not they require mpi.  Independent of whether mpi is installed on a system, sst-core can be configured using --disable-mpi.  The MPICC variable will contain either 'mpicc' or 'gcc' ( or variant ).  I'm assuming the 'mpi' string will be in whatever mpi compiler is selected based on my sample set of 1   test platform.

This PR simply creates a variable SST_MPICC which can be queried by CMakeLists.txt files. For this PR, hpe_phold uses the --parallel-load option which is not compiled into SST when --mpi-disable is set.


