### PR TITLE
Enabling use of  SST16 JSON timing files with SST15 compatible scripts

### DIFF
--- a/scripts/json-timing-convertor.py
+++ b/scripts/json-timing-convertor.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2017-2026 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# json-timing-converter.py
+#
+# Converts SST16+ json timing data files to SST15 format
+
+import json
+import sys
+
+UNITS={
+    'B'     : 1,
+    'KB'    : 1E3,
+    'MB'    : 1E6,
+    'GB'    : 1E9,
+    'TB'    : 1E12,
+}
+
+def getFactor(unit):
+    if unit not in UNITS.keys():
+        print(f"error: {unit} not in [{UNITS}]")
+        sys.exit(1)
+    return UNITS[unit]
+
+def toB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1]))
+
+def toKB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1])/1E3)
+
+def toMB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1])/1E6)
+
+def assertSeconds(s):
+    if s.split()[1] != "s":
+        print(f"error: value not in seconds: {s}")
+        sys.exit(1)
+    return float(s.split()[0])
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print("Usage: json-timing-convertor timing-file.json")
+        exit(1)
+
+    jsonFile = sys.argv[1]
+
+    with open(jsonFile) as f:
+        jsonDict = json.load(f)
+
+    metadata=jsonDict['metadata']
+    regions=jsonDict['regions']
+    resources=jsonDict['resources']
+
+    sst15Dict={ 
+        'timing-info': {
+            "local_max_rss":             toKB(resources['local_max_rss']),
+            "global_max_rss":            toKB(resources['global_max_rss']),
+            "local_max_pf":               int(resources['local_max_page_faults'].split()[0]),
+            "global_pf":                  int(resources['global_page_faults']   .split()[0]),
+            "global_max_io_in":           int(resources['global_max_io_in']     .split()[0]),
+            "global_max_io_out":          int(resources['global_max_io_out']    .split()[0]),
+            "global_max_sync_data_size":  toB(resources['global_max_sync_data_size']),
+            "global_sync_data_size":      toB(resources['global_sync_data_size']),
+            "max_mempool_size":           toB(resources['max_mempool_size']),
+            "global_mempool_size":        toB(resources['global_mempool_size']),
+            "global_active_activities":   int(resources['global_undeleted_activities']),
+            "global_current_tv_depth":    int(resources['global_current_timevortex_depth'].split()[0]),
+            "global_max_tv_depth":        int(resources['global_max_timevortex_depth'].split()[0]),
+            "ranks":                       int(metadata['ranks']),
+            "threads":                     int(metadata['threads']),
+            "max_build_time":     assertSeconds(regions['total']['build']['duration']),
+            "max_run_time":       assertSeconds(regions['total']['execute']['run']['duration']),
+            "max_total_time":     assertSeconds(regions['total']['duration']),
+            "simulated_time_ua":               metadata['simulation_time']
+        }
+    }
+
+    print(json.dumps(sst15Dict, indent=2))
+

--- a/scripts/sqlutils.py
+++ b/scripts/sqlutils.py
@@ -121,6 +121,68 @@ keyDict = {
     sdlInfoTable: []
 }
 
+UNITS={
+    'B'     : 1,
+    'KB'    : 1E3,
+    'MB'    : 1E6,
+    'GB'    : 1E9,
+    'TB'    : 1E12,
+}
+
+def getFactor(unit):
+    if unit not in UNITS.keys():
+        print(f"error: {unit} not in [{UNITS}]")
+        sys.exit(1)
+    return UNITS[unit]
+
+def toB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1]))
+
+def toKB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1])/1E3)
+
+def toMB(s):
+    return round(float(s.split()[0]) * getFactor(s.split()[1])/1E6)
+
+def assertSeconds(s):
+    if s.split()[1] != "s":
+        print(f"error: value not in seconds: {s}")
+        sys.exit(1)
+    return float(s.split()[0])
+
+# To smooth transition from SST15 to SST16
+def convertToSST15(jsonFile):
+    with open(jsonFile) as f:
+        sst16Dict = json.load(f)
+    metadata  = sst16Dict['metadata']
+    regions   = sst16Dict['regions']
+    resources = sst16Dict['resources']
+
+    sst15Dict={ 
+        'timing-info': {
+            "local_max_rss":             toKB(resources['local_max_rss']),
+            "global_max_rss":            toKB(resources['global_max_rss']),
+            "local_max_pf":               int(resources['local_max_page_faults'].split()[0]),
+            "global_pf":                  int(resources['global_page_faults']   .split()[0]),
+            "global_max_io_in":           int(resources['global_max_io_in']     .split()[0]),
+            "global_max_io_out":          int(resources['global_max_io_out']    .split()[0]),
+            "global_max_sync_data_size":  toB(resources['global_max_sync_data_size']),
+            "global_sync_data_size":      toB(resources['global_sync_data_size']),
+            "max_mempool_size":           toB(resources['max_mempool_size']),
+            "global_mempool_size":        toB(resources['global_mempool_size']),
+            "global_active_activities":   int(resources['global_undeleted_activities']),
+            "global_current_tv_depth":    int(resources['global_current_timevortex_depth'].split()[0]),
+            "global_max_tv_depth":        int(resources['global_max_timevortex_depth'].split()[0]),
+            "ranks":                       int(metadata['ranks']),
+            "threads":                     int(metadata['threads']),
+            "max_build_time":     assertSeconds(regions['total']['build']['duration']),
+            "max_run_time":       assertSeconds(regions['total']['execute']['run']['duration']),
+            "max_total_time":     assertSeconds(regions['total']['duration']),
+            "simulated_time_ua":               metadata['simulation_time']
+        }
+    }
+    return sst15Dict
+
 def log_sql_callback(statement):
     print("Executing SQL statement:", statement)
 
@@ -158,9 +220,12 @@ class sqldb():
     def close(self):
         self.con.close()
 
-    def insertFromJSON(self, jobid, jsonFile, jsonKey, tableName):
-        with open(jsonFile) as f:
-            jsonDict = json.load(f)
+    def insertFromJSON(self, jobid, jsonFile, jsonKey, tableName, convert):
+        if convert:
+            jsonDict = convertToSST15(jsonFile)
+        else:
+            with open(jsonFile) as f:
+                jsonDict = json.load(f)
         jsonInfo = jsonDict[jsonKey]
         data = ( jobid, )
         for k in self.sortedKeyDict[tableName]:
@@ -180,7 +245,8 @@ class sqldb():
     def timing_info(self, *, jsonFile:str=None, jobpath:str, jobid:int):
         if jsonFile == None:
             jsonFile=f"{jobpath}/timing.json"
-        self.insertFromJSON(jobid, jsonFile, 'timing-info', timingInfoTable)
+        # TODO last param is True if SST version >= 16
+        self.insertFromJSON(jobid, jsonFile, 'timing-info', timingInfoTable, True)
 
     def file_info(self, *, jobpath:str, jobid:int):
         # .../_grid_perf/687804907541/_cpt/1_500000/grid_4_0.bin

--- a/scripts/sqlutils.py
+++ b/scripts/sqlutils.py
@@ -188,8 +188,9 @@ def log_sql_callback(statement):
 
 class sqldb():
     
-    def __init__(self, dbFile, sdl_params: dict, logging):
+    def __init__(self, dbFile, sdl_params: dict, sst16plus: bool, logging):
         self.con = sqlite3.connect(dbFile)
+        self.sst16plus = sst16plus
         if logging==True:
             self.con.set_trace_callback(log_sql_callback)
         self.cur = self.con.cursor()
@@ -220,8 +221,8 @@ class sqldb():
     def close(self):
         self.con.close()
 
-    def insertFromJSON(self, jobid, jsonFile, jsonKey, tableName, convert):
-        if convert:
+    def insertFromJSON(self, jobid, jsonFile, jsonKey, tableName, sst16plus):
+        if sst16plus:
             jsonDict = convertToSST15(jsonFile)
         else:
             with open(jsonFile) as f:
@@ -245,8 +246,7 @@ class sqldb():
     def timing_info(self, *, jsonFile:str=None, jobpath:str, jobid:int):
         if jsonFile == None:
             jsonFile=f"{jobpath}/timing.json"
-        # TODO last param is True if SST version >= 16
-        self.insertFromJSON(jobid, jsonFile, 'timing-info', timingInfoTable, True)
+        self.insertFromJSON(jobid, jsonFile, 'timing-info', timingInfoTable, self.sst16plus)
 
     def file_info(self, *, jobpath:str, jobid:int):
         # .../_grid_perf/687804907541/_cpt/1_500000/grid_4_0.bin

--- a/scripts/sst-sweeper.py
+++ b/scripts/sst-sweeper.py
@@ -120,7 +120,9 @@ class JobEntry():
         self.setdeps = False
 
         self.sstopts = f"--num-threads={self.threads}"
-        self.sstopts += f" --print-timing-info=4 --timing-info-json=timing.json"
+        #TODO LEGACY
+        # self.sstopts += f" --print-timing-info=4 --timing-info-json=timing.json"
+        self.sstopts += f" --print-timing-info=4 --profiling-output=timing.json"
         self.sstopts += " --output-config=config.py --parallel-output"
         # --output-json=config.json" 
         for opt in sst_params:

--- a/scripts/sst-sweeper.py
+++ b/scripts/sst-sweeper.py
@@ -96,7 +96,7 @@ def range_from_str(s: str) -> range:
     return range(*values)
 
 class JobEntry():
-    def __init__(self, *, sdlFile:str, options:list, sim_controls:list, ranks:int, threads:int, sst_params:list, sdl_params:list, predecessors:list = []):
+    def __init__(self, *, sdlFile:str, options:list, sim_controls:list, sst16plus:bool, ranks:int, threads:int, sst_params:list, sdl_params:list, predecessors:list = []):
         
         self.jtype = JobType.BASE
         self.predecessors = predecessors
@@ -120,11 +120,11 @@ class JobEntry():
         self.setdeps = False
 
         self.sstopts = f"--num-threads={self.threads}"
-        #TODO LEGACY
-        # self.sstopts += f" --print-timing-info=4 --timing-info-json=timing.json"
-        self.sstopts += f" --print-timing-info=4 --profiling-output=timing.json"
+        if sst16plus:
+            self.sstopts += f" --print-timing-info=4 --profiling-output=timing.json"
+        else:
+            self.sstopts += f" --print-timing-info=4 --timing-info-json=timing.json"
         self.sstopts += " --output-config=config.py --parallel-output"
-        # --output-json=config.json" 
         for opt in sst_params:
             self.sstopts += f" --{opt}={sst_params[opt]}"
         
@@ -216,7 +216,7 @@ class JobEntry():
         return jobstring
 
 class JobManager():
-    def __init__(self, sdl, options, sim_control_params, job_sequencer_params, sst_params: list, sdl_params: list ):
+    def __init__(self, sdl, options, sim_control_params, job_sequencer_params, sst_params: list, sdl_params: list):
         print("\nCreating Job Manager")
         # Ok to omit clocks which is used for calculating the number of checkpoints 
         # when 'numcpt' is not set and checkpoint or restart is enabled
@@ -261,8 +261,24 @@ class JobManager():
             self.rundir=f"{rdir}.{i}"
         os.makedirs(self.rundir)
         # print(f"{g_pfx} Jobs will run in: {self.rundir}")
+        # sst version
+        self.jutil.exec(cmd='sst --version')
+        sst_version_string = self.jutil.res1
+        sst_version_match=re.search(r'SST-Core Version \((.+)[,\)]?.+$', sst_version_string)
+        if sst_version_match:
+            self.sst_version=sst_version_match.group(1).split(',')[0]
+        else:
+            self.sst_version="?"
+        print(f"sst {self.sst_version}")
+        major=self.sst_version.split('.')[0]
+        self.sst16plus = True
+        try:
+            if int(major) < 16:
+                self.sst16plus = False 
+        except:
+            self.sst16plus = True           
         # database
-        self.sqldb = sqlutils.sqldb(self.db, self.sdl_params, self.logging)
+        self.sqldb = sqlutils.sqldb(self.db, self.sdl_params, self.sst16plus, self.logging)
     def add_job(self, entry:JobEntry):
         id = self.next_id
         self.joblist[id] = entry
@@ -339,15 +355,6 @@ class JobManager():
         elif entry.jtype==JobType.COMPLETION:
             self.pp_remote(comp_id=jobid)
 
-        # sst version
-        self.jutil.exec(cmd='sst --version')
-        sst_version_string = self.jutil.res1
-        sst_version_match=re.search(r'SST-Core Version \((.+)[,\)]?.+$', sst_version_string)
-        if sst_version_match:
-            sst_version=sst_version_match.group(1).split(',')[0]
-        else:
-            sst_version="?"
-
         self.sqldb.job_info( jobid=jobid, dataDict={
             "jobname": entry.jobname,
             "friend": friend,
@@ -359,7 +366,7 @@ class JobManager():
             "nodeclamp" : self.nodeclamp,
             "jobnodes"  : entry.nodes,
             "cwd": cwd,
-            "sst_version": sst_version,
+            "sst_version": self.sst_version,
             "os_type": g_os_type,
             "date":  datetime.now().strftime("%Y.%m.%d %H:%M") 
         } )
@@ -823,6 +830,7 @@ if __name__ == '__main__':
                     sdlFile=sdlFile,
                     options=options,
                     sim_controls=sim_control_params,
+                    sst16plus=jobmgr.sst16plus,
                     ranks=r,
                     threads=t,
                     sst_params=sst_params,

--- a/test/noodle/sweep.json
+++ b/test/noodle/sweep.json
@@ -2,7 +2,8 @@
     "job_sequencer" :
     {
         "seq"       : ["BASE_CPT_RST", "Select simulation sequence: BASE|BASE_CPT|BASE_CPT_RST"],
-        "simperiod" : ["1000",        "checkpoint sim period in ns"]
+        "simperiod" : ["1000",        "checkpoint sim period in ns"],
+        "numcpt"    : ["0", "Estimated number of checkpoints. When 0, count is calculated as sdl['clocks']/simperiod"]	
     },
     "sim_controls"  :
     {


### PR DESCRIPTION
SST 16.0 has consolidated timing and profiling data into a single json and removed support for --timing-info-json option.
The PR provides a script to convert sst16 JSON files to sst15 JSON files thereby enabling reuse of existing scripts and allowing time for migrating these scripts to support the new format.

In addition, the some conversation function is defined in sst-sweeper.py.

Currently, this branch only works with SST 16.  The code to select the sst16 format or sst15 format (natively) still needs to be added.

More testing is needed to make sure the assumptions on the formats themselves are correct (e.g. units always in seconds, conversion from GB/MB/KB are correct, etc... )

Assuming the new formats remain stable, I can change the scripts to consume the new formats natively and convert the older formats to the new ones.